### PR TITLE
fix: missing include in docview/commonstruct.h

### DIFF
--- a/application/pdfControl/docview/commonstruct.h
+++ b/application/pdfControl/docview/commonstruct.h
@@ -4,6 +4,7 @@
 #include <QList>
 #include <QString>
 #include <QDateTime>
+#include <QRectF>
 
 #include <QMetaType>
 


### PR DESCRIPTION
Fixes #1