### PR TITLE
fix: remove missing header from .pri

### DIFF
--- a/src/widgets/widgets.pri
+++ b/src/widgets/widgets.pri
@@ -1,5 +1,4 @@
 HEADERS += \
-    $$PWD/FileViewWidget.h \
     $$PWD/AttrScrollWidget.h \
     $$PWD/FileAttrWidget.h \
     $$PWD/FindWidget.h \


### PR DESCRIPTION
The file is not found and produces a warning from qmake:
WARNING: Failure to find:
.../src/widgets/FileViewWidget.h