### PR TITLE
fix: 修复djvu格式文件，使用放大镜显示空白

### DIFF
--- a/reader/MainWindow.cpp
+++ b/reader/MainWindow.cpp
@@ -167,6 +167,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
     }
 
     QSettings settings(QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).filePath("config.conf"), QSettings::IniFormat, this);
+    qDebug() << "配置文件路径: " << QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).filePath("config.conf");
 
     settings.setValue("LASTWIDTH", QString::number(width()));
 

--- a/reader/browser/BrowserMagniFier.cpp
+++ b/reader/browser/BrowserMagniFier.cpp
@@ -55,7 +55,16 @@ void ReadMagnifierManager::run()
         m_tTasklst.clear();
 
         if (task.page) {
-            const QImage &image = task.page->getImagePoint(task.scaleFactor, task.mousePos);
+//            const QImage &image = task.page->getImagePoint(task.scaleFactor, task.mousePos);
+            QImage image;
+            //qDebug() << "task.scaleFactor: " << task.scaleFactor;
+            if (Dr::FileType::DJVU == task.page->fileType()  && task.scaleFactor <= 2.25) {
+                //缩放比例小于30%时，DJVU文档做了一个特殊处理，因为djvu底层在缩放比小的时候无法准确的获取出当前鼠标位置的图片
+                image = task.page->getCurImagePoint(task.mousePos);
+            } else {
+                image = task.page->getImagePoint(task.scaleFactor, task.mousePos);
+            }
+
             QMetaObject::invokeMethod(task.target, task.slotFun.toStdString().c_str(), Qt::QueuedConnection, Q_ARG(const MagnifierInfo_t &, task), Q_ARG(const QImage &, image));
         }
 
@@ -133,6 +142,7 @@ void BrowserMagniFier::showMagnigierImage(QPoint mousePos, QPoint magnifierPos, 
 
         setMagniFierImage(image);
     } else {
+        //qDebug() << "放大镜 page 为空！" ;
         setMagniFierImage(QImage());
     }
 
@@ -159,12 +169,14 @@ void BrowserMagniFier::showMagnigierImage(QPoint mousePos, QPoint magnifierPos, 
 
 void BrowserMagniFier::onUpdateMagnifierImage(const MagnifierInfo_t &task, const QImage &image)
 {
+    //qDebug() << "更新放大镜画面！";
     if (task.mousePos == m_lastPoint && qFuzzyCompare(task.scaleFactor, m_lastScaleFactor))
         setMagniFierImage(image);
 }
 
 void BrowserMagniFier::setMagniFierImage(const QImage &image)
 {
+    //qDebug() << "开始绘制放大镜画面...";
     QPixmap pix(static_cast<int>(this->width() * dApp->devicePixelRatio()), static_cast<int>(this->height() * dApp->devicePixelRatio()));
 
     pix.fill(Qt::transparent);
@@ -191,6 +203,7 @@ void BrowserMagniFier::setMagniFierImage(const QImage &image)
         painter.drawImage(0, 0, im.scaled(static_cast<int>(240 * dApp->devicePixelRatio()), static_cast<int>(240 * dApp->devicePixelRatio()), Qt::KeepAspectRatio, Qt::SmoothTransformation));
     } else {
         painter.fillRect(this->rect(), Qt::white);
+        //qDebug() << "未获取到需要放大的图片！图片为空！";
     }
     painter.restore();
 
@@ -199,4 +212,5 @@ void BrowserMagniFier::setMagniFierImage(const QImage &image)
     pix.setDevicePixelRatio(dApp->devicePixelRatio());
 
     setPixmap(pix);
+    //qDebug() << "放大镜画面绘制完成";
 }

--- a/reader/browser/BrowserMenu.cpp
+++ b/reader/browser/BrowserMenu.cpp
@@ -34,6 +34,7 @@ BrowserMenu::BrowserMenu(QWidget *parent) : DMenu(parent)
 void BrowserMenu::initActions(DocSheet *sheet, int index, SheetMenuType_e type, const QString &copytext)
 {
     m_type = type;
+    qDebug() << "打开右键菜单: " << type;
     m_pColorWidgetAction = nullptr;
     if (type == DOC_MENU_ANNO_ICON) {
         createAction(tr("Copy"), "CopyAnnoText");

--- a/reader/browser/BrowserPage.cpp
+++ b/reader/browser/BrowserPage.cpp
@@ -891,6 +891,11 @@ QPointF BrowserPage::getTopLeftPos()
     return p;
 }
 
+Dr::FileType BrowserPage::fileType()
+{
+    return m_sheet->fileType();
+}
+
 bool BrowserPage::removeAnnotation(deepin_reader::Annotation *annota)
 {
     if (nullptr == annota)

--- a/reader/browser/BrowserPage.h
+++ b/reader/browser/BrowserPage.h
@@ -359,6 +359,13 @@ public:
      */
     QPointF getTopLeftPos();
 
+    /**
+     * @brief fileType
+     * 获取文件类型
+     * @return
+     */
+    Dr::FileType fileType();
+
 private:
     /**
      * @brief handleRenderFinished

--- a/reader/browser/SheetBrowser.cpp
+++ b/reader/browser/SheetBrowser.cpp
@@ -1115,14 +1115,17 @@ void SheetBrowser::mousePressEvent(QMouseEvent *event)
             connect(&menu, &BrowserMenu::sigMenuHide, this, &SheetBrowser::onRemoveIconAnnotSelect);
 
             if (annotation && annotation->annotationType() == deepin_reader::Annotation::AText) {
+                qDebug() << "文字注释(图标)";
                 if (m_lastSelectIconAnnotPage)
                     m_lastSelectIconAnnotPage->setDrawMoveIconRect(false);
                 //文字注释(图标)
                 menu.initActions(m_sheet, item->itemIndex(), SheetMenuType_e::DOC_MENU_ANNO_ICON, annotation->annotationText());
             } else if (selectWord && selectWord->isSelected() && !selectWords.isEmpty()) {
+                qDebug() << "选择文字";
                 //选择文字
                 menu.initActions(m_sheet, item->itemIndex(), SheetMenuType_e::DOC_MENU_SELECT_TEXT);
             } else if (annotation && annotation->annotationType() == deepin_reader::Annotation::AHighlight) {
+                qDebug() << "文字高亮注释";
                 //文字高亮注释
                 menu.initActions(m_sheet, item->itemIndex(), SheetMenuType_e::DOC_MENU_ANNO_HIGHLIGHT, annotation->annotationText());
             } else if (nullptr != item) {
@@ -1567,11 +1570,13 @@ void SheetBrowser::openMagnifier()
 {
     if (nullptr == m_magnifierLabel) {
         m_magnifierLabel = new BrowserMagniFier(this);
+        qDebug() << "新建放大镜!";
     } else {
         m_magnifierLabel->raise();
 
         m_magnifierLabel->show();
     }
+    qDebug() << "打开放大镜！ m_magnifierLabel: " << m_magnifierLabel ;
 
     setDragMode(QGraphicsView::NoDrag);
 
@@ -1582,6 +1587,7 @@ void SheetBrowser::openMagnifier()
 
 void SheetBrowser::closeMagnifier()
 {
+    qDebug() << "关闭放大镜！ m_magnifierLabel: " << m_magnifierLabel;
     if (nullptr != m_magnifierLabel) {
         m_magnifierLabel->hide();
 

--- a/reader/document/DjVuModel.cpp
+++ b/reader/document/DjVuModel.cpp
@@ -496,6 +496,7 @@ QImage DjVuPage::render(int width, int height, const QRect &slice)const
     QImage image(static_cast<int>(renderrect.w),  static_cast<int>(renderrect.h), QImage::Format_RGB32);
 
     if (!ddjvu_page_render(page, DDJVU_RENDER_COLOR, &pagerect, &renderrect, m_parent->m_format, static_cast<unsigned long>(image.bytesPerLine()), reinterpret_cast< char * >(image.bits()))) {
+        qDebug() << "DJVU 不能获取到当前位置的图片";
         image = QImage();
     }
 
@@ -532,6 +533,7 @@ deepin_reader::DjVuDocument *DjVuDocument::loadDocument(const QString &filePath,
     waitForMessageTag(context, DDJVU_DOCINFO);
 
     if (ddjvu_document_decoding_error(document)) {
+        qWarning() << "djvu 文件解码失败！";
         ddjvu_document_release(document);
         ddjvu_context_release(context);
 

--- a/reader/uiframe/CentralDocPage.cpp
+++ b/reader/uiframe/CentralDocPage.cpp
@@ -506,6 +506,7 @@ DocSheet *CentralDocPage::getSheet(const QString &filePath)
 
 void CentralDocPage::handleShortcut(const QString &s)
 {
+    qDebug() << "键盘按下: " << s;
     if (s == Dr::key_esc && m_slideWidget) {
         quitSlide();
         return;
@@ -613,6 +614,7 @@ void CentralDocPage::openMagnifer()
 //  取消放大镜
 void CentralDocPage::quitMagnifer()
 {
+    qDebug() << "取消放大镜";
     if (!m_magniferSheet.isNull() && m_magniferSheet->magnifierOpened()) {
         m_magniferSheet->closeMagnifier();
         m_magniferSheet = nullptr;

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -91,6 +91,7 @@ DocSheet::DocSheet(const Dr::FileType &fileType, const QString &filePath,  QWidg
     connect(m_renderer, &SheetRenderer::sigOpened, this, &DocSheet::onOpened);
 
     m_browser = new SheetBrowser(this);
+    qDebug() << "新建右侧视图";
     m_browser->setMinimumWidth(DocSheet::BrowserMinWidth);
 
     if (Dr::PDF == fileType)


### PR DESCRIPTION
Description:  有djvu底层库不能准确的识别到当前放大镜所在位置的图片

Log:  修复djvu格式文件，使用放大镜显示空白

Bug: https://pms.uniontech.com/bug-view-154771.html