### PR TITLE
fix: 修复docx格式，全屏或退出全屏时会自动跳到当前页的页首

### DIFF
--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -951,6 +951,7 @@ bool DocSheet::isFullScreen()
 
 void DocSheet::openFullScreen()
 {
+    qDebug() << "打开全屏！";
     CentralDocPage *doc = static_cast<CentralDocPage *>(parent());
     if (nullptr == doc)
         return;
@@ -972,6 +973,7 @@ void DocSheet::openFullScreen()
 
 bool DocSheet::closeFullScreen(bool force)
 {
+    qDebug() << "关闭全屏！";
     CentralDocPage *doc = static_cast<CentralDocPage *>(parent());
     if (nullptr == doc)
         return false;
@@ -1281,9 +1283,10 @@ QSizeF DocSheet::pageSizeByIndex(int index)
 
 void DocSheet::resetChildParent()
 {
+    qDebug() << "重置侧边栏的父对象！";
     m_sidebar->setParent(nullptr);
     m_sidebar->setParent(this);
 
-    m_browser->setParent(nullptr);
-    m_browser->setParent(this);
+//    m_browser->setParent(nullptr);
+//    m_browser->setParent(this);
 }


### PR DESCRIPTION
Description:  由于右侧文档显示界面重复刷新导致

Log:  修复docx格式，全屏或退出全屏时会自动跳到当前页的页首

Bug: https://pms.uniontech.com/bug-view-154723.html