### PR TITLE
fix: 修复双屏时，查看快捷键面板时，面板位置不是居中显示

### DIFF
--- a/reader/widgets/ShortCutShow.cpp
+++ b/reader/widgets/ShortCutShow.cpp
@@ -47,9 +47,11 @@ void ShortCutShow::setSheet(DocSheet *sheet)
 
 void ShortCutShow::show()
 {
-    QRect rect = qApp->desktop()->geometry();
+    //多屏情况下bug修复， 将快捷键预览框显示在主屏中央。
+    QRect rect = QGuiApplication::primaryScreen()->geometry();
     QPoint pos(rect.x() + rect.width() / 2, rect.y() + rect.height() / 2);
 
+    qDebug() << "快捷键预览框显示位置: " << pos;
     QJsonObject shortcutObj;
     QJsonArray jsonGroups;
     QString strvalue;


### PR DESCRIPTION
Description: 修复双屏时，查看快捷键面板时，面板位置不是居中显示

Log: 修复双屏时，查看快捷键面板时，面板位置不是居中显示

Bug: https://pms.uniontech.com/bug-view-164953.html