### PR TITLE
fix: 修复当书签与超链接重叠时，点击书签，会触发超链接

### DIFF
--- a/reader/browser/BrowserPage.cpp
+++ b/reader/browser/BrowserPage.cpp
@@ -1092,6 +1092,18 @@ BrowserAnnotation *BrowserPage::getBrowserAnnotation(const QPointF &point)
     return nullptr;
 }
 
+bool BrowserPage::isExitBookMark(const QPointF &mousePoint)
+{
+    QRect rect(
+        static_cast<int>(bookmarkRect().x()),
+        static_cast<int>(10),
+        39, 39);
+    //qDebug() << "bookmarkMouseRect(): " << bookmarkMouseRect() << "mousePoint" << mousePoint;
+    //qDebug() << "当前鼠标位置是否存在书签: " << bookmarkMouseRect().contains(mousePoint.toPoint());
+    bool flag = bookmarkMouseRect().contains(mousePoint.toPoint());
+    return flag;
+}
+
 BrowserWord *BrowserPage::getBrowserWord(const QPointF &point)
 {
     BrowserWord *item = nullptr;

--- a/reader/browser/BrowserPage.h
+++ b/reader/browser/BrowserPage.h
@@ -296,6 +296,13 @@ public:
     BrowserAnnotation *getBrowserAnnotation(const QPointF &point);
 
     /**
+     * @brief isExitBookMark 光标的位置是否与书签的位置重合
+     * @param point
+     * @return true:重合 false:不重合
+     */
+    bool isExitBookMark(const QPointF &point);
+
+    /**
      * @brief getBrowserWord
      * 根据坐标点获得当前的文字
      * @param point PageItem坐标系统

--- a/reader/document/PDFModel.cpp
+++ b/reader/document/PDFModel.cpp
@@ -115,7 +115,7 @@ Link PDFPage::getLinkAtPoint(const QPointF &pos)
             //i++;
             //qDebug() << "当前页的超链接" << i << ":" << linkAnnot->url() << " , 是否选中: " << linkAnnot->pointIn(pos);
             if (linkAnnot && linkAnnot->pointIn(pos)) {
-                qDebug()  << "解析前 >>> 当前选中的超链接: " << linkAnnot->url() << linkAnnot->filePath() << " , 当前页包含超链接的数量: " << dlinkAnnots.size();
+                //qDebug()  << "解析前 >>> 当前选中的超链接: " << linkAnnot->url() << linkAnnot->filePath() << " , 当前页包含超链接的数量: " << dlinkAnnots.size();
                 if (!linkAnnot->isValid())
                     m_page->initAnnot(annot);
 
@@ -201,7 +201,7 @@ Link PDFPage::getLinkAtPoint(const QPointF &pos)
                 default:
                     break;
                 }
-                qDebug() << "解析后 >> 当前选中的超链接: " << link.urlOrFileName;
+                //qDebug() << "解析后 >> 当前选中的超链接: " << link.urlOrFileName;
                 link.top = linkAnnot->offset().y();
                 return link;
             }


### PR DESCRIPTION
Description: 未对书签区域做屏蔽

Log: 修复当书签与超链接重叠时，点击书签，会触发超链接

Bug: https://pms.uniontech.com/bug-view-164267.html