### PR TITLE
fix: 修复文档查看器打开任意pdf，左上角未显示放大或缩小的百分比

### DIFF
--- a/reader/widgets/ScaleWidget.cpp
+++ b/reader/widgets/ScaleWidget.cpp
@@ -44,6 +44,9 @@ void ScaleWidget::initWidget()
 
     m_arrowBtn = new DIconButton(QStyle::SP_ArrowDown, m_lineEdit);
     m_arrowBtn->setObjectName("editArrowBtn");
+    //添加显示比例值默认值
+    m_arrowBtn->setFixedSize(NormalModeArrowBtnSize, NormalModeArrowBtnSize);
+    m_arrowBtn->move(m_lineEdit->width() - m_arrowBtn->width() - 2, m_lineEdit->height() / 2 - m_arrowBtn->height() / 2);
 #ifdef DTKWIDGET_CLASS_DSizeMode
     qInfo() << "Compact mode support!!!";
     onSizeModeChanged(DGuiApplicationHelper::instance()->sizeMode());


### PR DESCRIPTION
修复文档查看器打开任意pdf，左上角未显示放大或缩小的百分比

Bug: https://pms.uniontech.com/bug-view-248095.html
Log: 修复文档查看器打开任意pdf，左上角未显示放大或缩小的百分比