### PR TITLE
feat: Change default shortcuts popup position

### DIFF
--- a/reader/widgets/ShortCutShow.cpp
+++ b/reader/widgets/ShortCutShow.cpp
@@ -8,6 +8,8 @@
 #include "Global.h"
 #include "DocSheet.h"
 
+#include <DGuiApplicationHelper>
+
 #include <QProcess>
 #include <QDesktopWidget>
 #include <QJsonDocument>
@@ -34,6 +36,18 @@ void ShortCutShow::show()
 {
     QRect rect = qApp->desktop()->geometry();
     QPoint pos(rect.x() + rect.width() / 2, rect.y() + rect.height() / 2);
+    // 获取当前焦点位置（光标所在屏幕中心）
+    QScreen *screen = nullptr;
+    if (DGuiApplicationHelper::isTabletEnvironment()) {
+        // bug 88079 避免屏幕旋转弹出位置错误
+        screen = qApp->primaryScreen();
+    } else {
+        screen = QGuiApplication::screenAt(QCursor::pos());
+    }
+
+    if (screen) {
+        pos = screen->geometry().center();
+    }
 
     QJsonObject shortcutObj;
     QJsonArray jsonGroups;


### PR DESCRIPTION
调整默认快捷键浮窗弹出位置.
现在将显示在焦点屏幕(光标所在屏幕)中央.

Log: 调整默认快捷键浮窗弹出位置
Task: https://pms.uniontech.com/task-view-332271.html
Influence: Shortcuts