### PR TITLE
chore: Bump version to 6.0.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+deepin-reader (6.0.9) unstable; urgency=medium
+
+  * fix: Fixed the problem that when opening any PDF in the document viewer,
+         the enlargement or reduction percentage is not displayed in the
+         upper left corner(Bug: 248095)
+  * feat: Change default shortcuts popup position(Task: 332271)
+         (Influence: Shortcuts)
+
+ -- renbin <renbin@uniontech.com>  Wed, 27 Mar 2024 15:47:28 +0800
+
 deepin-reader (6.0.8) unstable; urgency=medium
 
   * change log 6.0.8.


### PR DESCRIPTION
Bump version to 6.0.9
PR:
* https://github.com/linuxdeepin/deepin-reader/pull/97
* https://github.com/linuxdeepin/deepin-reader/pull/98

Log: Bump version to 6.0.9