### PR TITLE
chore: build tests with cpp 14

### DIFF
--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -6,7 +6,7 @@ QT += core gui sql printsupport dbus testlib widgets
 #QMAKE_CXXFLAGS += -g -fsanitize=undefined,address -O2
 #QMAKE_LFLAGS += -g -fsanitize=undefined,address -O2
 
-CONFIG += c++11 link_pkgconfig resources_big testcase no_testcase_installs
+CONFIG += c++14 link_pkgconfig resources_big testcase no_testcase_installs
 
 #访问私有方法 -fno-access-control
 QMAKE_CXXFLAGS += -g -Wall -fprofile-arcs -ftest-coverage -fno-access-control -O0 -fno-inline


### PR DESCRIPTION
Log: gtest 1.14  requires C++14 or higher now, this only changes the version used in tests, not in the rest of the build