### PR TITLE
fix: Fix runtime issue on linglong box

### DIFF
--- a/reader/Application.cpp
+++ b/reader/Application.cpp
@@ -23,7 +23,7 @@ Application::Application(int &argc, char **argv)
     setApplicationName("deepin-reader");
     setOrganizationName("deepin");
     //setWindowIcon(QIcon::fromTheme("deepin-reader"));     //耗时40ms
-    setApplicationVersion(DApplication::buildVersion("1.0.0"));
+    setApplicationVersion(DApplication::buildVersion(APP_VERSION));
     setApplicationAcknowledgementPage("https://www.deepin.org/acknowledgments/deepin_reader");
     setApplicationDisplayName(tr("Document Viewer"));
     setApplicationDescription(tr("Document Viewer is a tool for reading document files, supporting PDF, DJVU, DOCX etc."));

--- a/reader/document/Model.cpp
+++ b/reader/document/Model.cpp
@@ -42,6 +42,20 @@ deepin_reader::Document *deepin_reader::DocumentFactory::getDocument(const int &
         QString tmpHtmlFilePath = convertedFileDir + "/word/temp.html";
         QString realFilePath = convertedFileDir + "/temp.pdf";
 
+        // QDir convertedDir(convertedFileDir);
+        // if (!convertedDir.exists()) {
+        //     bool flag = convertedDir.mkdir(convertedFileDir);
+        //     qDebug() << "创建文件夹" << convertedFileDir << "是否成功？" << flag;
+        // } else {
+        //     qDebug() << "文件夹" << convertedFileDir << "已经存在！";
+        // }
+        // qDebug() << "targetDoc: " << targetDoc;
+        // qDebug() << "tmpHtmlFilePath: " << tmpHtmlFilePath;
+        // qDebug() << "realFilePath: " << realFilePath;
+
+        QString prefix = INSTALL_PREFIX;
+        // qDebug() << "应用安装路径: " << prefix;
+
         QFile file(filePath);
         if (!file.copy(targetDoc)) {
             qInfo() << QString("copy %1 failed.").arg(filePath);
@@ -87,7 +101,15 @@ deepin_reader::Document *deepin_reader::DocumentFactory::getDocument(const int &
         *pprocess = &converter;
         converter.setWorkingDirectory(convertedFileDir + "/word");
         qDebug() << "正在将docx文档转换成html..." << tmpHtmlFilePath;
-        QString pandocCommand = "pandoc " +  targetDoc + " -o " + tmpHtmlFilePath;
+        // QFile targetDocFile(targetDoc);
+        // if (targetDocFile.exists()) {
+        //     qDebug() << "文档" << targetDocFile.fileName() << "存在！";
+        // } else {
+        //     qDebug() << "文档" << targetDocFile.fileName() << "不存在！";
+        // }
+        QString pandocDataDir = prefix + "/share/pandoc/data";
+        QString pandocCommand = QString("pandoc %1 --data-dir=%2 -o %3").arg(targetDoc).arg(pandocDataDir).arg(tmpHtmlFilePath);
+
         qDebug() << "执行命令: " << pandocCommand;
         converter.start(pandocCommand);
         if (!converter.waitForStarted()) {
@@ -119,7 +141,8 @@ deepin_reader::Document *deepin_reader::DocumentFactory::getDocument(const int &
         *pprocess = &converter2;
         converter2.setWorkingDirectory(convertedFileDir + "/word");
         qDebug() << "正在将html转换成pdf..." << realFilePath;
-        QString htmltopdfCommand = "/usr/lib/deepin-reader/htmltopdf " +  tmpHtmlFilePath + " " + realFilePath;
+
+        QString htmltopdfCommand = prefix + "/lib/deepin-reader/htmltopdf " +  tmpHtmlFilePath + " " + realFilePath;
         qDebug() << "执行命令: " << htmltopdfCommand;
         converter2.start(htmltopdfCommand);
         if (!converter2.waitForStarted()) {

--- a/reader/document/document.pri
+++ b/reader/document/document.pri
@@ -9,3 +9,5 @@ SOURCES += \
     $$PWD/Model.cpp
 
 INCLUDEPATH += $$PWD
+
+DEFINES += INSTALL_PREFIX=\\\"$$PREFIX\\\"

--- a/reader/reader.pro
+++ b/reader/reader.pro
@@ -21,7 +21,8 @@ QMAKE_CXXFLAGS += -fPIE
 
 QMAKE_LFLAGS += -pie
 
-VERSION=$(DEB_VERSION_UPSTREAM)
+DEFINES += APP_VERSION=\\\"$$VERSION\\\"
+message("APP_VERSION: "$$VERSION)
 
 contains(QMAKE_HOST.arch, mips64):{
     QMAKE_CXXFLAGS += "-O3 -ftree-vectorize -march=loongson3a -mhard-float -mno-micromips -mno-mips16 -flax-vector-conversions -mloongson-ext2 -mloongson-mmi"

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -28,6 +28,9 @@ DEFINES += UTSOURCEDIR=\"\\\"$$PWD\\\"\"
 
 LIBS += -lgtest
 
+DEFINES += APP_VERSION=\\\"$$VERSION\\\"
+message("APP_VERSION: "$$VERSION)
+
 #target
 TARGET = test-deepin-reader
 


### PR DESCRIPTION
The pandoc and htmltopdf are installed in other path by PREFIX defined, the patch fix its runtime issue. The webengine bin and resources must be copy into the same dir with htmltodpf installed path.

Log: fix runtime issue on linglong.