### PR TITLE
fix: shortcut copy text not work

### DIFF
--- a/reader/MainWindow.cpp
+++ b/reader/MainWindow.cpp
@@ -465,11 +465,11 @@ QString MainWindow::libPath(const QString &strlib)
     QStringList list = dir.entryList(QStringList() << (strlib + "*"), QDir::NoDotAndDotDot | QDir::Files);   //filter name with strlib
 
     if (list.contains(strlib))
-        return strlib;
+        return dir.filePath(strlib);
 
     list.sort();
     if (list.size() > 0)
-        return list.last();
+        return dir.filePath(list.last());
 
     return "";
 }

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -508,13 +508,13 @@ void DocSheet::copySelectedText()
     if (selectedWordsText.isEmpty())
         return;
 #if _ZPD_
-    int intercept = -1;
+    int intercept = 0;
     if (getLoadLibsInstance()->m_document_clip_copy) {
         qInfo() << "当前文档: ***"/* << filePath()*/;
         getLoadLibsInstance()->m_document_clip_copy(filePath().toLocal8Bit().data(), &intercept);
         qInfo() << "是否拦截不允许复制(1:拦截 0:不拦截): " << intercept;
     }
-    if (intercept) return;
+    if (intercept > 0) return;
 #endif
     QClipboard *clipboard = DApplication::clipboard();  //获取系统剪贴板指针
     clipboard->setText(selectedWordsText);


### PR DESCRIPTION
As title.
The previous fix bb8f3e921e4b3efe47f185b28164df3ef6f12613 worked for menu copy, but not for shortcut copy.
And 3fcf6f588aaf0e4755445bf7a8963bf9f458ff05 remove ZPD code by default.

Log: Fix shortcut copy text not work.
Bug: https://pms.uniontech.com/bug-view-234693.html
Influence: shortcut-copy