### PR TITLE
fix: [build]Enable test only for amd64 and arm64

### DIFF
--- a/deepin_reader.pro
+++ b/deepin_reader.pro
@@ -9,12 +9,14 @@ CONFIG  += ordered
 #QMAKE_CXXFLAGS += -g -fsanitize=undefined,address -O2
 #QMAKE_LFLAGS += -g -fsanitize=undefined,address -O2
 
+message("Build on host arch: $$QMAKE_HOST.arch")
+
 SUBDIRS += 3rdparty/deepin-pdfium
 
 SUBDIRS += htmltopdf
 
 SUBDIRS += reader
 
-!contains(QMAKE_HOST.arch, loong64): {
+contains(QMAKE_HOST.arch, x86_64) | contains(QMAKE_HOST.arch, aarch64): {
     SUBDIRS += tests
 }


### PR DESCRIPTION
Enable the testes only for x86_64 and aarch64 arch.

Log: Fix build for special arch.