### PR TITLE
chore: Bump version to 6.5.19 and update dependencies

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.18.1
+  version: 6.5.19.1
   kind: app
   description: |
     reader for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-reader (6.5.19) unstable; urgency=medium
+
+  * Update version to 6.519
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 02 Apr 2025 14:58:31 +0800
+
 deepin-reader (6.5.18) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,10 @@ Standards-Version: 4.5.0
 
 Package: deepin-reader
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, pandoc
+Depends: 
+    ${shlibs:Depends}, 
+    ${misc:Depends}, 
+    pandoc,  
+    libqt6webenginecore6-bin [!mipsel !mips64el] | libqt5core5a
 Description: a tool for reading document files.
  Document Viewer is a tool for reading document files, supporting PDF, DJVU, DOCX etc.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.18.1
+  version: 6.5.19.1
   kind: app
   description: |
     reader for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.18.1
+  version: 6.5.19.1
   kind: app
   description: |
     reader for deepin os.


### PR DESCRIPTION
Update the version of deepin-reader to 6.5.19 in all relevant files and add a new dependency for libqt6webenginecore6-bin. Update changelog accordingly.