### PR TITLE
fix: Rename pdf library

### DIFF
--- a/3rdparty/deepin-pdfium/src/src.pro
+++ b/3rdparty/deepin-pdfium/src/src.pro
@@ -1,4 +1,4 @@
-TARGET = $$PWD/../lib/deepin-pdfium
+TARGET = $$PWD/../lib/deepin-pdfium-reader
 
 TEMPLATE = lib
 

--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -47,7 +47,7 @@ build: |
     deepin-reader
     ../lib/deepin-reader/htmltopdf
     pandoc
-    libdeepin-pdfium.so
+    libdeepin-pdfium-reader.so
     # 定制插件不存在
     libzpdcallback.so
   )

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -47,7 +47,7 @@ build: |
     deepin-reader
     ../lib/deepin-reader/htmltopdf
     pandoc
-    libdeepin-pdfium.so
+    libdeepin-pdfium-reader.so
     # 定制插件不存在
     libzpdcallback.so
   )

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -47,7 +47,7 @@ build: |
     deepin-reader
     ../lib/deepin-reader/htmltopdf
     pandoc
-    libdeepin-pdfium.so
+    libdeepin-pdfium-reader.so
     # 定制插件不存在
     libzpdcallback.so
   )

--- a/reader/src.pri
+++ b/reader/src.pri
@@ -27,7 +27,7 @@ RESOURCES    += $$PWD/../resources/resources.qrc
 #link
 #由于自动化构建暂时无法自动下载sub module,目前手动内置第三方库
 INCLUDEPATH += $$PWD/../3rdparty/deepin-pdfium/include
-LIBS += -L$$PWD/../3rdparty/deepin-pdfium/lib -ldeepin-pdfium -ldl
+LIBS += -L$$PWD/../3rdparty/deepin-pdfium/lib -ldeepin-pdfium-reader -ldl
 
 # 基础 Qt 模块
 equals(QT_MAJOR_VERSION, 6) {


### PR DESCRIPTION
The conflict between deepin-pdfium library and file manager installation, modify the name to avoid this issue.

Log: Rename pdf library.