### PR TITLE
fix: Add dynamic path resolution for htmltopdf

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.35.1
+  version: 6.5.36.1
   kind: app
   description: |
     reader for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-reader (6.5.36) unstable; urgency=medium
+
+  * bug: Add dynamic path resolution for htmltopdf
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 03 Sep 2025 09:29:10 +0800
+
 deepin-reader (6.5.35) unstable; urgency=medium
 
   * chore: Update version to 6.5.35

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.35.1
+  version: 6.5.36.1
   kind: app
   description: |
     reader for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.35.1
+  version: 6.5.36.1
   kind: app
   description: |
     reader for deepin os.

--- a/reader/document/Model.cpp
+++ b/reader/document/Model.cpp
@@ -17,7 +17,30 @@
 #include <QDir>
 #include <QTimer>
 #include <QTemporaryFile>
+#include <QLibraryInfo>
 
+
+namespace {
+
+QString getHtmlToPdfPath() {
+
+    QString path = QString(INSTALL_PREFIX) + "/lib/deepin-reader/htmltopdf";
+    if (QFile::exists(path)) {
+        qDebug() << "Found htmltopdf in INSTALL_PREFIX: " << path;
+        return path;
+    }
+
+    path = QLibraryInfo::path(QLibraryInfo::LibrariesPath) + "/deepin-reader/htmltopdf";
+    if (QFile::exists(path)) {
+        qDebug() << "Found htmltopdf in LibrariesPath: " << path;
+        return path;
+    }
+
+    qWarning() << "Not found htmltopdf";
+    return QString();
+}
+
+}
 namespace deepin_reader {
 deepin_reader::Document *deepin_reader::DocumentFactory::getDocument(const int &fileType,
                                                                      const QString &filePath,
@@ -161,7 +184,7 @@ deepin_reader::Document *deepin_reader::DocumentFactory::getDocument(const int &
         converter2.setWorkingDirectory(convertedFileDir + "/word");
         qInfo() << "Converting HTML to PDF:" << realFilePath;
 
-        QString htmltopdfCommand = prefix + "/lib/deepin-reader/htmltopdf " +  tmpHtmlFilePath + " " + realFilePath;
+        QString htmltopdfCommand = getHtmlToPdfPath() + " " + tmpHtmlFilePath + " " + realFilePath;
         qDebug() << "执行命令: " << htmltopdfCommand;
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         converter2.start(htmltopdfCommand);


### PR DESCRIPTION
fix: Add dynamic path resolution for htmltopdf
    
    Added a new function getHtmlToPdfPath() to dynamically resolve the path for htmltopdf. Updated the htmltopdfCommand in getDocument to use this function instead of a hardcoded path, improving code flexibility and maintainability.
    
    bug: https://pms.uniontech.com/bug-view-332133.html
