### PR TITLE
fix(reader): remove unsafe QObject* logging in SideBarImageViewModel

### DIFF
--- a/reader/sidebar/SideBarImageViewModel.cpp
+++ b/reader/sidebar/SideBarImageViewModel.cpp
@@ -263,15 +263,12 @@ void SideBarImageViewModel::removePageIndex(int pageIndex)
 
 void SideBarImageViewModel::removeItemForAnno(deepin_reader::Annotation *annotation)
 {
-    qCDebug(appLog) << "Removing item for annotation:" << annotation;
     int index = findItemForAnno(annotation);
     if (index >= 0) {
-        qCDebug(appLog) << "Removing item for annotation:" << annotation << "found";
         beginResetModel();
         m_pagelst.removeAt(index);
         endResetModel();
     }
-    qCDebug(appLog) << "Removing item for annotation:" << annotation << "end";
 }
 
 void SideBarImageViewModel::getModelIndexImageInfo(int modelIndex, ImagePageInfo_t &tImagePageInfo)
@@ -285,14 +282,12 @@ void SideBarImageViewModel::getModelIndexImageInfo(int modelIndex, ImagePageInfo
 
 int SideBarImageViewModel::findItemForAnno(deepin_reader::Annotation *annotation)
 {
-    qCDebug(appLog) << "Finding item for annotation:" << annotation;
     int count = m_pagelst.size();
     for (int index = 0; index < count; index++) {
         if (annotation == m_pagelst.at(index).annotation) {
             return index;
         }
     }
-    qCDebug(appLog) << "Finding item for annotation:" << annotation << "end";
     return -1;
 }
 


### PR DESCRIPTION
* Remove qCDebug statements that printed Annotation*/QObject* in SideBarImageViewModel::removeItemForAnno and findItemForAnno Drop the ad-hoc test block that logged deleted QObject* to reproduce crashes
* Avoids implicit dereference by Qt’s debug stream overloads that could crash

bug： https://pms.uniontech.com/bug-view-335473.html