### PR TITLE
fix(pdfium): allow zero-length WriteBlock() no-op

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -13,6 +13,11 @@ Files: .gitignore
 Copyright: None
 License: CC0-1.0
 
+# project (tooling/config)
+Files: .project
+Copyright: None
+License: CC0-1.0
+
 # xml toml json conf yaml sh
 Files:  *.toml *.json *conf *.yaml *.sh
 Copyright: None

--- a/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium/core/fpdfapi/edit/cpdf_creator.cpp
+++ b/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium/core/fpdfapi/edit/cpdf_creator.cpp
@@ -76,8 +76,15 @@ bool CFX_FileBufferArchive::Flush() {
 }
 
 bool CFX_FileBufferArchive::WriteBlock(const void* pBuf, size_t size) {
+  // A zero-length write is a valid no-op. Some callers may pass nullptr when
+  // size==0 (e.g. empty name/string serialization). Treat it as success to
+  // avoid aborting on benign inputs.
+  if (size == 0)
+    return true;
+
   ASSERT(pBuf);
-  ASSERT(size > 0);
+  if (!pBuf)
+    return false;
 
   const uint8_t* buffer = reinterpret_cast<const uint8_t*>(pBuf);
   size_t temp_size = size;

--- a/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium/core/fpdfapi/parser/cpdf_stream.cpp
+++ b/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium/core/fpdfapi/parser/cpdf_stream.cpp
@@ -203,7 +203,7 @@ bool CPDF_Stream::WriteTo(IFX_ArchiveStream* archive,
   if (!archive->WriteString("stream\r\n"))
     return false;
 
-  if (size && !archive->WriteBlock(data.data(), size))
+  if (!archive->WriteBlock(data.data(), size))
     return false;
 
   if (!archive->WriteString("\r\nendstream"))

--- a/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium/core/fxcrt/cfx_memorystream.cpp
+++ b/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium/core/fxcrt/cfx_memorystream.cpp
@@ -68,7 +68,14 @@ size_t CFX_MemoryStream::ReadBlock(void* buffer, size_t size) {
 bool CFX_MemoryStream::WriteBlockAtOffset(const void* buffer,
                                           FX_FILESIZE offset,
                                           size_t size) {
-  if (!buffer || offset < 0 || !size)
+  if (offset < 0)
+    return false;
+
+  if (size == 0)
+    return true;
+
+  DCHECK(buffer);
+  if (!buffer)
     return false;
 
   FX_SAFE_SIZE_T safe_new_pos = size;

--- a/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium/core/fxcrt/fx_stream.h
+++ b/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium/core/fxcrt/fx_stream.h
@@ -30,6 +30,8 @@ struct FxFolderHandleCloser {
 
 class IFX_WriteStream {
  public:
+  // When `size` is 0, treat it as a no-op and return true. That is also the
+  // only time when `pData` can be null.
   virtual bool WriteBlock(const void* pData, size_t size) = 0;
   virtual bool WriteString(ByteStringView str) = 0;
 


### PR DESCRIPTION
Treat WriteBlock(size==0) as success and only require non-null data when size>0. This prevents aborts when serializing empty names/streams and aligns implementations/call sites with the interface contract.

log: fix bug

upstream:https://github.com/chromium/pdfium/commit/0e723c531512df64967edec91e3259c3da6ddd9d#diff-89818b20cf16ed5dfbf8b50d13c34fc3596cacf04bd3c4da3c2d433a6bbe6526 Bug: https://pms.uniontech.com/bug-view-353429.html