### PR TITLE
fix(browser): fix annotation jump position in fit-to-width mode

### DIFF
--- a/reader/browser/SheetBrowser.cpp
+++ b/reader/browser/SheetBrowser.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -891,8 +891,6 @@ void SheetBrowser::deform(SheetOperation &operation)
     qCDebug(appLog) << "Deforming view with scale factor:" << operation.scaleFactor
              << "mode:" << operation.scaleMode << "rotation:" << operation.rotation;
              
-    m_lastScaleFactor = operation.scaleFactor;
-
     const qreal safeMaxWidth = qFuzzyIsNull(m_maxWidth) ? 1.0 : m_maxWidth;
     const qreal safeMaxHeight = qFuzzyIsNull(m_maxHeight) ? (qFuzzyIsNull(m_maxWidth) ? 1.0 : m_maxWidth) : m_maxHeight;
 
@@ -934,6 +932,8 @@ void SheetBrowser::deform(SheetOperation &operation)
             operation.scaleMode = Dr::ScaleFactorMode;
         break;
     }
+
+    m_lastScaleFactor = operation.scaleFactor;
 
     int page = operation.currentPage;
     //进行render 并算出最宽的一行


### PR DESCRIPTION
Move m_lastScaleFactor assignment after scale mode adjustment in deform() to ensure it reflects the actual rendering scale factor.

修复注释跳转位置偏下的问题，将 m_lastScaleFactor 赋值移到
缩放模式调整之后，确保使用实际渲染缩放比例计算跳转位置。

Log: 修复注释跳转位置不正确
PMS: BUG-311189
Influence: 修复在适应页宽等模式下点击注释列表跳转时，跳转位置偏下导致注释不可见的问题。