### PR TITLE
fix(browser): intercept PageDown/PageUp to snap to page boundary

### DIFF
--- a/reader/browser/SheetBrowser.cpp
+++ b/reader/browser/SheetBrowser.cpp
@@ -27,6 +27,7 @@
 #include <DGuiApplicationHelper>
 
 #include <QGraphicsItem>
+#include <QKeyEvent>
 #include <QScrollBar>
 #include <QTimer>
 #include <QApplication>
@@ -750,6 +751,21 @@ void SheetBrowser::jumpToHighLight(deepin_reader::Annotation *annotation, const 
 
     jump2PagePos(jumpPage, posLeft, posTop);
     qCDebug(appLog) << "SheetBrowser::jumpToHighLight() - Jump to high light completed";
+}
+
+void SheetBrowser::keyPressEvent(QKeyEvent *event)
+{
+    if (m_sheet) {
+        if (event->key() == Qt::Key_PageDown && !event->isAutoRepeat()) {
+            m_sheet->jumpToNextPage();
+            return;
+        }
+        if (event->key() == Qt::Key_PageUp && !event->isAutoRepeat()) {
+            m_sheet->jumpToPrevPage();
+            return;
+        }
+    }
+    DGraphicsView::keyPressEvent(event);
 }
 
 void SheetBrowser::wheelEvent(QWheelEvent *event)

--- a/reader/browser/SheetBrowser.h
+++ b/reader/browser/SheetBrowser.h
@@ -409,6 +409,13 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
 
     /**
+     * @brief keyPressEvent
+     * 键盘按键事件，适合高度模式下拦截PageDown/PageUp实现精确翻页
+     * @param event
+     */
+    void keyPressEvent(QKeyEvent *event) override;
+
+    /**
      * @brief focusOutEvent
      * 失去焦点处理
      * @param event


### PR DESCRIPTION
Override keyPressEvent in SheetBrowser to handle PageDown/PageUp by jumping to exact page boundaries instead of pixel-based scrolling.

重写SheetBrowser的keyPressEvent，PageDown/PageUp直接跳转到
精确页面边界，避免像素滚动导致的累积偏移。

Log: 修复PageDown翻页时页面边界逐渐偏移的问题
PMS: BUG-353721
Influence: 所有缩放模式下PageDown/PageUp均精确跳转到上/下一页，不再有累积偏移。