### PR TITLE
fix(pdfium): resolve buffer overflow in PDF link handling

### DIFF
--- a/3rdparty/deepin-pdfium/src/dpdfpage.cpp
+++ b/3rdparty/deepin-pdfium/src/dpdfpage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -328,18 +328,22 @@ bool DPdfPagePrivate::loadAnnots()
 
             //获取类型
             if (PDFACTION_URI == type) {
-                char uri[256] = {0};
-                unsigned long lenth = FPDFAction_GetURIPath(m_doc, action, uri, 256);
-                if (0 != lenth) {
-                    dAnnot->setUrl(uri);
+                // 先获取所需缓冲区大小
+                unsigned long length = FPDFAction_GetURIPath(m_doc, action, nullptr, 0);
+                if (length > 0) {
+                    QByteArray uriBuffer(length, 0);
+                    FPDFAction_GetURIPath(m_doc, action, uriBuffer.data(), length);
+                    dAnnot->setUrl(QString::fromUtf8(uriBuffer.constData()));
                 }
 
                 dAnnot->setLinkType(DPdfLinkAnnot::Uri);
             } else if (PDFACTION_REMOTEGOTO == type) {
-                char filePath[256] = {0};
-                unsigned long lenth = FPDFAction_GetFilePath(action, filePath, 256);
-                if (0 != lenth) {
-                    dAnnot->setFilePath(filePath);
+                // 先获取所需缓冲区大小
+                unsigned long length = FPDFAction_GetFilePath(action, nullptr, 0);
+                if (length > 0) {
+                    QByteArray pathBuffer(length, 0);
+                    FPDFAction_GetFilePath(action, pathBuffer.data(), length);
+                    dAnnot->setFilePath(QString::fromUtf8(pathBuffer.constData()));
                 }
 
                 dAnnot->setLinkType(DPdfLinkAnnot::RemoteGoTo);


### PR DESCRIPTION
Fix potential buffer overflow when extracting PDF URI and file paths by using dynamic buffer allocation instead of fixed-size arrays.

修复 PDF 链接处理中的缓冲区溢出问题，使用动态缓冲区分配替代固定大小数组。

Log: 修复 PDF 链接缓冲区溢出
PMS: BUG-348865
Influence: 修复后 PDF 文档中的 URI 和文件路径链接能够正确处理，避免缓冲区溢出导致的安全隐患和程序崩溃，提升 PDF 阅读器的稳定性。