### PR TITLE
fix(djvu): copy network djvu files to local temp dir before loading

### DIFF
--- a/reader/app/Global.cpp
+++ b/reader/app/Global.cpp
@@ -9,6 +9,7 @@
 #include <QMimeType>
 #include <QMimeDatabase>
 #include <QDebug>
+#include <QStorageInfo>
 #include <DGuiApplicationHelper>
 
 namespace Dr {
@@ -55,6 +56,24 @@ FileType fileType(const QString &filePath)
 
     qCDebug(appLog) << "Final file type:" << static_cast<int>(fileType);
     return fileType;
+}
+
+bool isNetworkPath(const QString &filePath)
+{
+    const QStorageInfo storage(filePath);
+    if (!storage.isValid() || storage.isRoot())
+        return false;
+
+    const QByteArray fsType = storage.fileSystemType().toLower();
+    if (fsType.contains("nfs") || fsType.contains("cifs") ||
+        fsType.contains("smb") || fsType.contains("sshfs") ||
+        fsType.contains("gvfsd"))
+        return true;
+
+    if (filePath.startsWith("/run/user/") && filePath.contains("/gvfs/"))
+        return true;
+
+    return false;
 }
 
 }

--- a/reader/app/Global.h
+++ b/reader/app/Global.h
@@ -9,6 +9,7 @@
 #include "DebugTimeManager.h"
 
 #include <QString>
+#include <QStorageInfo>
 
 namespace Dr {
 
@@ -45,6 +46,7 @@ enum FileType {
 #endif
 };
 FileType fileType(const QString &filePath);
+bool isNetworkPath(const QString &filePath);
 
 /**
  * @brief The Rotation enum

--- a/reader/document/DjVuModel.cpp
+++ b/reader/document/DjVuModel.cpp
@@ -511,7 +511,7 @@ QImage DjVuPage::render(int width, int height, const QRect &slice)const
     return image;
 }
 
-deepin_reader::DjVuDocument *DjVuDocument::loadDocument(const QString &filePath, deepin_reader::Document::Error &error)
+deepin_reader::DjVuDocument *DjVuDocument::loadDocument(const QString &filePath, deepin_reader::Document::Error &error, const QString &displayFilePath)
 {
     qCInfo(appLog) << "Starting to load DjVu document from path:" << filePath;
     ddjvu_context_t *context = ddjvu_context_create("deepin_reader");
@@ -549,7 +549,7 @@ deepin_reader::DjVuDocument *DjVuDocument::loadDocument(const QString &filePath,
 
     DjVuDocument *djvuDocument = new DjVuDocument(context, document);
 
-    djvuDocument->m_filePath = filePath;
+    djvuDocument->m_filePath = displayFilePath.isEmpty() ? filePath : displayFilePath;
 
     error = Document::NoError;
     qCInfo(appLog) << "Successfully loaded DjVu document from:" << filePath << "with" << djvuDocument->pageCount() << "pages";

--- a/reader/document/DjVuModel.h
+++ b/reader/document/DjVuModel.h
@@ -71,7 +71,7 @@ public:
 
     Properties properties() const override;
 
-    static deepin_reader::DjVuDocument *loadDocument(const QString &filePath, deepin_reader::Document::Error &error);
+    static deepin_reader::DjVuDocument *loadDocument(const QString &filePath, deepin_reader::Document::Error &error, const QString &displayFilePath = "");
 
 private:
     DjVuDocument(ddjvu_context_t *context, ddjvu_document_t *document);

--- a/reader/document/Model.cpp
+++ b/reader/document/Model.cpp
@@ -19,6 +19,7 @@
 #include <QTimer>
 #include <QTemporaryFile>
 #include <QLibraryInfo>
+#include "Global.h"
 
 
 namespace {
@@ -94,7 +95,22 @@ deepin_reader::Document *deepin_reader::DocumentFactory::getDocument(const int &
         document = deepin_reader::PDFDocument::loadDocument(filePath, password, error);
     } else if (Dr::DJVU == fileType) {
         qCDebug(appLog) << "Handling DJVU document";
-        document = deepin_reader::DjVuDocument::loadDocument(filePath, error);
+        if (Dr::isNetworkPath(filePath) && !convertedFileDir.isEmpty()) {
+            qCInfo(appLog) << "DJVU file is on network path, copying to local temp dir";
+            QString localFilePath = convertedFileDir + "/temp.djvu";
+            if (QFile::exists(localFilePath))
+                QFile::remove(localFilePath);
+
+            if (!QFile::copy(filePath, localFilePath)) {
+                qCritical() << "Failed to copy network DJVU file from" << filePath << "to" << localFilePath;
+                error = deepin_reader::Document::FileError;
+            } else {
+                qCInfo(appLog) << "Copied network DJVU to local:" << localFilePath;
+                document = deepin_reader::DjVuDocument::loadDocument(localFilePath, error, filePath);
+            }
+        } else {
+            document = deepin_reader::DjVuDocument::loadDocument(filePath, error);
+        }
 #ifdef XPS_SUPPORT_ENABLED
     } else if (Dr::XPS == fileType) {
         qCDebug(appLog) << "Handling XPS document";

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -869,6 +869,9 @@ QString DocSheet::openedFilePath()
     if (Dr::DOCX == fileType())
         return convertedFileDir() + "/temp.pdf";
 
+    if (Dr::DJVU == fileType() && Dr::isNetworkPath(filePath()))
+        return convertedFileDir() + "/temp.djvu";
+
     return filePath();
 }
 

--- a/tests/document/ut_model.cpp
+++ b/tests/document/ut_model.cpp
@@ -21,7 +21,7 @@ PDFDocument *loadpdfDocument_stub(const QString &, const QString &, deepin_reade
     return nullptr;
 }
 
-DjVuDocument *loaddjvuDocument_stub(const QString &, deepin_reader::Document::Error &error)
+DjVuDocument *loaddjvuDocument_stub(const QString &, deepin_reader::Document::Error &error, const QString & = "")
 {
     error = Document::FileError;
     return nullptr;


### PR DESCRIPTION
Network shares (SMB/NFS) cause extreme slowness due to libdjvu's
  random seek I/O pattern. Detect network paths via QStorageInfo and
  copy to local temp dir first, similar to how DOCX is handled.

log: fix bug

Bug: https://pms.uniontech.com/bug-view-354845.html