### PR TITLE
fix(tips): resolve annotation tooltip flash on desktop

### DIFF
--- a/reader/widgets/TipsWidget.cpp
+++ b/reader/widgets/TipsWidget.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -20,7 +20,7 @@ TipsWidget::TipsWidget(QWidget *parent) : DWidget(parent)
 {
     qCDebug(appLog) << "TipsWidget created, parent:" << parent;
     m_parent = parent;
-    setWindowFlags(Qt::ToolTip);
+    setWindowFlags(Qt::Tool);
     initWidget();
     onUpdateTheme();
 }


### PR DESCRIPTION
Change TipsWidget window flag from Qt::ToolTip to Qt::Tool so that the tooltip window minimizes together with its parent window when the user presses Win+D to show desktop.

修复鼠标悬浮在注释上按Win+D显示桌面时注释内容闪烁的问题，
将TipsWidget窗口标志从Qt::ToolTip改为Qt::Tool，
使其随父窗口一起最小化。

Log: 修复注释提示框在显示桌面时闪烁
PMS: BUG-362085
Influence: 鼠标悬浮在PDF注释上按Win+D返回桌面时不再出现注释内容闪烁。