### PR TITLE
fix: Abnormal page jump on thumbnail bookmark page

### DIFF
--- a/reader/sidebar/SheetSidebar.cpp
+++ b/reader/sidebar/SheetSidebar.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -549,13 +549,16 @@ bool SheetSidebar::event(QEvent *event)
     // qCDebug(appLog) << "SheetSidebar::event start - type:" << event->type();
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent *key_event = static_cast<QKeyEvent *>(event);
-        if (key_event->key() == Qt::Key_Menu && !key_event->isAutoRepeat()) {
-            // qCDebug(appLog) << "Key_Menu pressed, showing menu";
+        const bool isMenuKey = (key_event->key() == Qt::Key_Menu);
+        const bool isAltM = (key_event->key() == Qt::Key_M
+                             && (key_event->modifiers() & Qt::AltModifier));
+        if ((isMenuKey || isAltM) && !key_event->isAutoRepeat()) {
+            // Consume the event so it does not propagate to Qt's mnemonic /
+            // accelerator handling — otherwise the same Alt+M keeps the
+            // accelerator state active after exec() returns, causing the
+            // popup to jump and requiring a second ESC to dismiss it.
             showMenu();
-        }
-        if (key_event->key() == Qt::Key_M && (key_event->modifiers() & Qt::AltModifier) && !key_event->isAutoRepeat()) {
-            // qCDebug(appLog) << "Alt+M pressed, showing menu";
-            showMenu();
+            return true;
         }
     }
 

--- a/reader/sidebar/SideBarImageListview.cpp
+++ b/reader/sidebar/SideBarImageListview.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -66,8 +66,12 @@ void SideBarImageListView::showMenu()
         return;
     }
 
+    // visualRect() is in viewport coordinates, so map through viewport() —
+    // mapping through `this` adds a frame/margin offset and shifts the menu.
     const QRect &visualRect = this->visualRect(this->currentIndex());
-    QPoint point = mapToGlobal(QPoint(this->width() / 2 - 4, visualRect.y() + visualRect.height() / 2 - 4));
+    QPoint point = viewport()->mapToGlobal(
+        QPoint(viewport()->width() / 2 - 4,
+               visualRect.y() + visualRect.height() / 2 - 4));
     if (m_listType == E_SideBar::SIDE_NOTE) {
         qCDebug(appLog) << "Showing note menu";
         showNoteMenu(point);


### PR DESCRIPTION
log: In SheetSidebar::event(), return true after handling Alt+M / Key_Menu to consume the event. This prevents the event from propagating further and triggering Qt's mnemonic or accelerator key behaviors.

pms: bug-363119