### PR TITLE
fix(keyboard): 缩略图面板 viewport 焦点被重置导致键盘翻页失效

### DIFF
--- a/reader/sidebar/SideBarImageListview.cpp
+++ b/reader/sidebar/SideBarImageListview.cpp
@@ -28,6 +28,7 @@ SideBarImageListView::SideBarImageListView(DocSheet *sheet, QWidget *parent)
     setSpacing(4);
     setObjectName("sideBarImageListView");
     setFocusPolicy(Qt::ClickFocus);
+    viewport()->setObjectName("sideBarImageListViewViewport");
     setFrameShape(QFrame::NoFrame);
     setSelectionMode(QAbstractItemView::SingleSelection);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);


### PR DESCRIPTION
log:
- SideBarImageListView: 给 viewport 设置 objectName，避免 setObjectNoFocusPolicy 将其重置为 NoFocus，使点击缩略图后 Up/Down/PageUp/PageDown 键盘事件正确由列表视图处理而非穿透到文档视图

pms: bug-362813