### PR TITLE
fix(ui): fix long filename display in save dialog

### DIFF
--- a/reader/widgets/SaveDialog.cpp
+++ b/reader/widgets/SaveDialog.cpp
@@ -1,15 +1,21 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "SaveDialog.h"
 #include "ddlog.h"
 #include <QDebug>
+#include <QFontMetrics>
+#include <QGuiApplication>
 
 #include <DDialog>
 
 DWIDGET_USE_NAMESPACE
+
+namespace {
+constexpr int kMaxFileNameWidth = 400;
+}
 
 SaveDialog::SaveDialog(QObject *parent)
     : QObject(parent)
@@ -20,7 +26,9 @@ SaveDialog::SaveDialog(QObject *parent)
 int SaveDialog::showExitDialog(QString fileName, QWidget  *parent)
 {
     qCDebug(appLog) << "Showing save dialog for file:" << fileName << ", parent:" << parent;
-    DDialog dlg(tr("Save the changes to \"%1\"?").arg(fileName), "", parent);
+    QFontMetrics fm(QGuiApplication::font());
+    QString showName = fm.elidedText(fileName, Qt::ElideMiddle, kMaxFileNameWidth);
+    DDialog dlg(tr("Save the changes to \"%1\"?").arg(showName), "", parent);
     dlg.setIcon(QIcon::fromTheme("deepin-reader"));
     dlg.addButtons(QStringList() <<  tr("Cancel", "button") << tr("Discard", "button"));
     dlg.addButton(tr("Save", "button"), true, DDialog::ButtonRecommend);


### PR DESCRIPTION
Add file name length limiting to prevent layout issues with long filenames in the exit save dialog.

添加文件名长度限制，防止长文件名在退出保存对话框中导致布局问题。

Log: 修复保存对话框长文件名显示异常
PMS: BUG-339267
Influence: 修复了长文件名在保存对话框中显示异常的问题，避免界面布局错乱，提升用户体验。