### PR TITLE
fix(pdf): use UUID-only backup filename to avoid NAME_MAX overflow

### DIFF
--- a/3rdparty/deepin-pdfium/src/dpdfdoc.cpp
+++ b/3rdparty/deepin-pdfium/src/dpdfdoc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -245,7 +245,7 @@ bool DPdfDoc::save()
 
     QTemporaryDir tempDir;
 
-    QString tempFilePath = tempDir.path() + "/" + QUuid::createUuid().toString();
+    QString tempFilePath = tempDir.path() + "/" + QUuid::createUuid().toString(QUuid::WithoutBraces);
 
     saveWriter.setFileName(tempFilePath);
 
@@ -269,9 +269,10 @@ bool DPdfDoc::save()
 
     QString targetPath = d_func()->m_filePath;
 
-    // Extract directory and filename to create hidden backup file
+    // Use a UUID-only hidden file as backup to avoid long filename
+    // issues with NAME_MAX (255 bytes) on the backup path.
     QFileInfo fileInfo(targetPath);
-    QString backupPath = fileInfo.absolutePath() + "/." + fileInfo.fileName() + ".backup." + QUuid::createUuid().toString();
+    QString backupPath = fileInfo.absolutePath() + "/." + QUuid::createUuid().toString(QUuid::WithoutBraces);
 
     QFile targetFile(targetPath);
 


### PR DESCRIPTION
When saving files with very long filenames (especially with CJK characters that expand in UTF-8), the backup path
".{filename}.backup.{uuid}" could exceed the filesystem's NAME_MAX limit of 255 bytes per path component, causing save failures. Use a UUID-only hidden filename (".{uuid}") as backup, which is always 39 bytes and avoids the issue entirely.

使用纯UUID作为备份文件名，避免超长文件名导致的NAME_MAX溢出问题。
当保存带有超长文件名（特别是CJK字符在UTF-8中占多字节）的文件时，
原有的备份路径".{filename}.backup.{uuid}"可能超过文件系统的
NAME_MAX限制（255字节），导致保存失败。改为仅使用UUID作为隐藏
备份文件名（".{uuid}"），固定39字节，彻底避免此问题。

Log: 修复超长文件名保存失败问题
PMS: BUG-370563
Influence: 修复后带有超长文件名的PDF文档编辑后可正常保存，中英文混合文件名也能正常处理。

## Summary by Sourcery

Ensure PDF saving uses UUID-only temporary and backup filenames to avoid filesystem NAME_MAX overflows with very long filenames.

Bug Fixes:
- Prevent save failures for PDFs with very long or multi-byte filenames by replacing filename-based backup paths with fixed-length UUID-only hidden backup files.

Enhancements:
- Standardize temporary and backup file UUIDs to omit braces for consistent, compact file naming.
- Update SPDX copyright header years for the PDF document implementation file.