### PR TITLE
fix(tests): 修复 test-prj-running.sh 脚本无法构建和生成覆盖率的问题

### DIFF
--- a/tests/test-prj-running.sh
+++ b/tests/test-prj-running.sh
@@ -4,37 +4,70 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+set -u
+
 builddir=build
 reportdir=build-ut
-# rm -rf $builddir
-# rm -rf ../$builddir
-# rm -rf $reportdir
-# rm -rf ../$reportdir
-# mkdir ../$builddir
-# mkdir ../$reportdir
-cd ../$builddir
-#编译（启用单元测试构建）
-# cmake -DCMAKE_SAFETYTEST_ARG="CMAKE_SAFETYTEST_ARG_ON" -DDOTEST=ON -DBUILD_TESTS=ON -DUSE_PDFIUM_BUNDLE=ON -DCMAKE_BUILD_TYPE=Debug ..
-make -j8
-#生成asan日志和ut测试xml结果
-./tests/test-deepin-reader --gtest_output=xml:./report/report_deepin-reader.xml
 
-workdir=$(cd ../$(dirname $0)/$builddir; pwd)
+# Resolve project root (parent of the tests/ directory that holds this script)
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+project_root="$(cd "${script_dir}/.." && pwd)"
 
-mkdir -p report
-#统计代码覆盖率并生成html报告
-lcov -d $workdir -c -o ./coverage.info
+build_path="${project_root}/${builddir}"
+report_path="${project_root}/${reportdir}"
 
-lcov --extract ./coverage.info '*/reader/*' -o  ./coverage.info
+# Fresh build directory to ensure a clean coverage run
+rm -rf "${build_path}"
+mkdir -p "${build_path}"
 
-lcov --remove ./coverage.info '*/tests/*' -o  ./coverage.info
+# Fresh report directory
+rm -rf "${report_path}"
+mkdir -p "${report_path}"
 
+cd "${build_path}"
+
+# Configure project with unit tests and coverage instrumentation enabled
+cmake -DCMAKE_SAFETYTEST_ARG="CMAKE_SAFETYTEST_ARG_ON" \
+      -DDOTEST=ON \
+      -DBUILD_TESTS=ON \
+      -DUSE_PDFIUM_BUNDLE=ON \
+      -DCMAKE_BUILD_TYPE=Debug \
+      "${project_root}"
+
+# Compile tests target
+make -j"$(nproc)" test-deepin-reader
+
+# Ensure report directory used by gtest exists inside the build tree
+mkdir -p "${build_path}/report"
+
+# Run tests and produce XML report
+./tests/test-deepin-reader --gtest_output=xml:"${build_path}/report/report_deepin-reader.xml"
+
+# Directory that holds coverage artifacts (build tree of the project)
+workdir="${build_path}"
+
+# Reset any stale coverage counters before recapture
+lcov --directory "${workdir}" --zerocounters || true
+
+# Re-run tests so .gcda files reflect a clean run
+./tests/test-deepin-reader --gtest_output=xml:"${build_path}/report/report_deepin-reader.xml"
+
+# Collect coverage data
+lcov -d "${workdir}" -c -o ./coverage.info
+
+# Keep only reader sources, drop tests themselves
+lcov --extract ./coverage.info '*/reader/*' -o ./coverage.info
+lcov --remove  ./coverage.info '*/tests/*' -o ./coverage.info
+
+# Generate HTML report
 genhtml -o ./html ./coverage.info
 
+# Rename main index for downstream tooling
 mv ./html/index.html ./html/cov_deepin-reader.html
-#对asan、ut、代码覆盖率结果收集至指定文件夹
-cp -r html ../$reportdir/
-cp -r report ../$reportdir/
-cp -r asan*.log* ../$reportdir/asan_deepin-reader.log 2>/dev/null || true
+
+# Publish artifacts into project report dir
+cp -r html  "${report_path}/"
+cp -r "${build_path}/report" "${report_path}/"
+cp -r asan*.log* "${report_path}/asan_deepin-reader.log" 2>/dev/null || true
 
 exit 0


### PR DESCRIPTION
问题：脚本中 cmake 配置命令被注释、build 目录未创建，导致
make 无 Makefile、测试可执行文件不存在、lcov 找不到 .gcda 文件，
最终生成空的 coverage.info。

修复：
- 自动创建 build 目录并执行 cmake 配置（启用 BUILD_TESTS、 USE_PDFIUM_BUNDLE、CMAKE_BUILD_TYPE=Debug、CMAKE_SAFETYTEST_ARG）
- 使用绝对路径与 script_dir 推导 project_root，避免依赖 PWD
- make 指定 test-deepin-reader 目标，使用 nproc 并行
- 测试执行前 zerocounters，保证覆盖率数据干净
- 报告产物按 build-ut/{html,report,asan.log} 固定输出

## Summary by Sourcery

Ensure the test-prj-running.sh script reliably builds the project, runs unit tests, and generates valid coverage and report artifacts.

Enhancements:
- Resolve the project root using the script location so the script is independent of the current working directory.
- Recreate build and report directories on each run to guarantee a clean test and coverage environment.
- Configure CMake with test and debug options enabled before building the test-deepin-reader target in parallel.
- Reset coverage counters and rerun tests to capture accurate coverage data, then filter and generate an HTML report.
- Standardize output locations for HTML coverage, test reports, and ASAN logs under the build-ut directory.