### PR TITLE
ci: upgrade actions/checkout to v7 with unsafe PR checkout

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump actions/checkout from v3 to v7 and enable allow-unsafe-pr-checkout option for pull request builds.

将 actions/checkout 从 v3 升级至 v7，并启用 allow-unsafe-pr-checkout 选项以支持 PR 构建。

Log: 升级 actions/checkout 至 v7
Influence: 更新 CI 静态检查的 checkout 动作版本，无功能影响。

## Summary by Sourcery

CI:
- Update cppcheck workflow to use actions/checkout v7 with allow-unsafe-pr-checkout enabled for pull request builds.