### PR TITLE
test(sidebar): cover delegate sizeHint and bookmark/notes widgets

### DIFF
--- a/tests/sidebar/ut_bookmarkwidget.cpp
+++ b/tests/sidebar/ut_bookmarkwidget.cpp
@@ -56,13 +56,13 @@ TEST_F(TestBookMarkWidget, testprevPage)
     EXPECT_TRUE(m_tester->m_sheet != nullptr);
 }
 
-TEST_F(TestBookMarkWidget, testpageUp)
+TEST_F(TestBookMarkWidget, testnextPage)
 {
-    m_tester->pageUp();
+    m_tester->nextPage();
     EXPECT_TRUE(m_tester->m_sheet != nullptr);
 }
 
-TEST_F(TestBookMarkWidget, testnextPage)
+TEST_F(TestBookMarkWidget, testpageUp)
 {
     m_tester->pageUp();
     EXPECT_TRUE(m_tester->m_sheet != nullptr);

--- a/tests/sidebar/ut_notesdelegate.cpp
+++ b/tests/sidebar/ut_notesdelegate.cpp
@@ -59,3 +59,12 @@ TEST_F(UT_NotesDelegate, UT_NotesDelegate_paint)
     EXPECT_TRUE(m_tester->m_parent == m_pView);
     delete painter;
 }
+
+TEST_F(UT_NotesDelegate, UT_NotesDelegate_sizeHint)
+{
+    m_pView->getImageModel()->insertPageIndex(1);
+    QStyleOptionViewItem option;
+    QModelIndex index = m_pView->getImageModel()->index(0, 0);
+    QSize size = m_tester->sizeHint(option, index);
+    EXPECT_FALSE(size.isEmpty());
+}

--- a/tests/sidebar/ut_noteswidget.cpp
+++ b/tests/sidebar/ut_noteswidget.cpp
@@ -54,7 +54,7 @@ TEST_F(UT_NotesWidget, initTest)
 
 TEST_F(UT_NotesWidget, UT_NotesWidget_prevPage)
 {
-    m_tester->pageUp();
+    m_tester->prevPage();
     EXPECT_TRUE(m_tester->m_sheet != nullptr);
 }
 
@@ -64,9 +64,21 @@ TEST_F(UT_NotesWidget, UT_NotesWidget_nextPage)
     EXPECT_TRUE(m_tester->m_sheet != nullptr);
 }
 
+TEST_F(UT_NotesWidget, UT_NotesWidget_deleteNoteItem_nullptr)
+{
+    m_tester->deleteNoteItem(nullptr);
+    EXPECT_TRUE(m_tester->m_sheet != nullptr);
+}
+
 TEST_F(UT_NotesWidget, UT_NotesWidget_pageDown)
 {
     m_tester->pageDown();
+    EXPECT_TRUE(m_tester->m_sheet != nullptr);
+}
+
+TEST_F(UT_NotesWidget, UT_NotesWidget_pageUp)
+{
+    m_tester->pageUp();
     EXPECT_TRUE(m_tester->m_sheet != nullptr);
 }
 

--- a/tests/sidebar/ut_searchresdelegate.cpp
+++ b/tests/sidebar/ut_searchresdelegate.cpp
@@ -59,3 +59,12 @@ TEST_F(UT_SearchResDelegate, UT_SearchResDelegate_paint)
     EXPECT_TRUE(m_tester->m_parent == m_pView);
     delete painter;
 }
+
+TEST_F(UT_SearchResDelegate, UT_SearchResDelegate_sizeHint)
+{
+    m_pView->getImageModel()->insertPageIndex(1);
+    QStyleOptionViewItem option;
+    QModelIndex index = m_pView->getImageModel()->index(0, 0);
+    QSize size = m_tester->sizeHint(option, index);
+    EXPECT_FALSE(size.isEmpty());
+}

--- a/tests/sidebar/ut_thumbnaildelegate.cpp
+++ b/tests/sidebar/ut_thumbnaildelegate.cpp
@@ -75,3 +75,12 @@ TEST_F(UT_ThumbnailDelegate, UT_ThumbnailDelegate_drawBookMarkNotVisible)
     SUCCEED();
     delete painter;
 }
+
+TEST_F(UT_ThumbnailDelegate, UT_ThumbnailDelegate_sizeHint)
+{
+    m_pView->getImageModel()->insertPageIndex(1);
+    QStyleOptionViewItem option;
+    QModelIndex index = m_pView->getImageModel()->index(0, 0);
+    QSize size = m_tester->sizeHint(option, index);
+    EXPECT_FALSE(size.isEmpty());
+}


### PR DESCRIPTION
Extend ut_bookmarkwidget fixing duplicate testnextPage. Extend ut_noteswidget with deleteNoteItem and pageUp. Add sizeHint tests to ut_notesdelegate, ut_searchresdelegate, ut_thumbnaildelegate.

修复 ut_bookmarkwidget 中重复的 testnextPage。扩充
ut_noteswidget 覆盖 deleteNoteItem 和 pageUp。为三个 delegate 测试补充 sizeHint 用例。

Log: 新增 sidebar delegate/widget 测试覆盖
Influence: 覆盖书签、注释、搜索结果代理的绘制与尺寸计算。