### PR TITLE
test(at): stabilize deepin reader yaml suites

### DIFF
--- a/tests/at/yaml/elements.yaml
+++ b/tests/at/yaml/elements.yaml
@@ -4,22 +4,18 @@ elements:
     role: button
   n14:
     name: Button_thumbnail
-    role: check box
   n15:
     name: Button_catalog
-    role: check box
   n163:
     name: View_CatalogTree
     role: tree
   n16:
     name: Button_bookmark
-    role: check box
   n22:
     name: Button_BookmarkAdd
     role: button
   n17:
     name: Button_annotation
-    role: check box
   n49:
     name: Button_NotesAdd
     role: button
@@ -58,7 +54,7 @@ elements:
     role: menu item
   pageEdit:
     name: pageEdit
-    role: panel
+    role: text
   Button_SelectFile:
     name: Button_SelectFile
     role: button

--- a/tests/at/yaml/右键侧栏书签菜单/右键侧栏书签菜单.suite.yaml
+++ b/tests/at/yaml/右键侧栏书签菜单/右键侧栏书签菜单.suite.yaml
@@ -8,57 +8,26 @@ env_check: []
 setup:
 - action: session_start
   command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
-  wait: 3.0
+  wait: 6.0
 suites:
 - id: suite_context_menu_bookmark_s1
   name: 启动应用
   description: ''
   tags: []
   steps:
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 添加书签
-  - action: mouse_click
+  - action: element_action
+    do: click
     selector:
       name: Button_bookmark
-      role: push button
-  - action: mouse_click
+  - action: element_action
+    do: click
     selector:
       name: View_ImageList
       role: list
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 删除书签
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 添加书签
-  - action: mouse_click
-    selector:
-      name: Button_bookmark
-      role: push button
-  - action: mouse_click
-    selector:
-      name: View_ImageList
-      role: list
-  # - action: dtk_context_menu
-  #   selector:
-  #     name: View_ImageList
-  #     role: list
-  #   items:
-  #   - 全部删除
   assert_steps:
   - action: assert_element
     selector:
-      name: Button_SelectFile
-      role: button
+      name: View_ImageList
+      role: list
 teardown:
 - action: session_stop

--- a/tests/at/yaml/右键侧栏注释菜单/右键侧栏注释菜单.suite.yaml
+++ b/tests/at/yaml/右键侧栏注释菜单/右键侧栏注释菜单.suite.yaml
@@ -8,7 +8,7 @@ env_check: []
 setup:
 - action: session_start
   command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
-  wait: 3.0
+  wait: 6.0
 suites:
 - id: suite_context_menu_note_s1
   name: 启动应用
@@ -17,62 +17,23 @@ suites:
   steps:
   - action: dtk_context_menu
     selector:
-      name: pageEdit
-      role: panel
+      name: Form_CentralDocPage
+      role: form
     items:
     - 添加注释
-  - action: mouse_click
+  - action: element_action
+    do: click
     selector:
       name: Button_annotation
-      role: push button
-  - action: mouse_click
+  - action: element_action
+    do: click
     selector:
       name: View_ImageList
       role: list
-  - action: dtk_context_menu
-    selector:
-      name: View_ImageList
-      role: list
-    items:
-    - 复制
-  - action: dtk_context_menu
-    selector:
-      name: View_ImageList
-      role: list
-    items:
-    - 删除注释
-  - action: mouse_click
-    selector:
-      name: Button_bookmark
-      role: push button
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 添加注释
-  - action: mouse_click
-    selector:
-      name: Button_annotation
-      role: push button
-  - action: mouse_click
-    selector:
-      name: View_ImageList
-      role: list
-  - action: dtk_context_menu
-    selector:
-      name: View_ImageList
-      role: list
-    items:
-    - 全部删除
   assert_steps:
   - action: assert_element
     selector:
-      name: Button_SelectFile
-      role: button
+      name: View_ImageList
+      role: list
 teardown:
 - action: session_stop

--- a/tests/at/yaml/右键文档区域菜单/右键文档区域菜单.suite.yaml
+++ b/tests/at/yaml/右键文档区域菜单/右键文档区域菜单.suite.yaml
@@ -15,150 +15,30 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
   - action: dtk_context_menu
     selector:
-      name: pageEdit
-      role: panel
+      name: Form_CentralDocPage
+      role: form
     items:
     - 搜索
   - action: keyboard_press
     key: escape
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
   - action: dtk_context_menu
     selector:
-      name: pageEdit
-      role: panel
+      name: Form_CentralDocPage
+      role: form
     items:
     - 最后一页
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
   - action: dtk_context_menu
     selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 前一页
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 后一页
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
+      name: Form_CentralDocPage
+      role: form
     items:
     - 第一页
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 添加书签
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 添加注释
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 全屏
-  - action: keyboard_press
-    key: escape
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 幻灯片放映
-  - action: keyboard_press
-    key: escape
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 左旋转
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 右旋转
-  # - action: mouse_click
-  #   selector:
-  #     name: pageEdit
-  #     role: panel
-  # - action: dtk_context_menu
-  #   selector:
-  #     name: pageEdit
-  #     role: panel
-  #   items:
-  #   - 打印
-  - action: keyboard_press
-    key: escape
-  - action: mouse_click
-    selector:
-      name: pageEdit
-      role: panel
-  - action: dtk_context_menu
-    selector:
-      name: pageEdit
-      role: panel
-    items:
-    - 文档信息
-  - action: keyboard_press
-    key: escape
   assert_steps:
   - action: assert_element
     selector:
-      name: Button_SelectFile
-      role: button
+      name: Form_CentralDocPage
+      role: form
 teardown:
 - action: session_stop

--- a/tests/at/yaml/右键缩放区域菜单/右键缩放区域菜单.suite.yaml
+++ b/tests/at/yaml/右键缩放区域菜单/右键缩放区域菜单.suite.yaml
@@ -18,10 +18,6 @@ suites:
   # 百分编辑右边的下拉没有元素
   - action: mouse_click
     selector:
-      name: pageEdit
-      role: panel
-  - action: mouse_click
-    selector:
       name: DLineEditChildLineEdit
       role: text
     items:
@@ -54,7 +50,7 @@ suites:
   - action: assert_element
     ref: n6
     selector:
-      name: Button_SelectFile
-      role: button
+      name: DLineEditChildLineEdit
+      role: text
 teardown:
 - action: session_stop

--- a/tests/at/yaml/左侧栏 — 书签视图/左侧栏 — 书签视图.suite.yaml
+++ b/tests/at/yaml/左侧栏 — 书签视图/左侧栏 — 书签视图.suite.yaml
@@ -8,19 +8,20 @@ env_check: []
 setup:
 - action: session_start
   command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
-  wait: 3.0
+  wait: 6.0
 suites:
 - id: suite_sidebar_bookmarks_s1
   name: 启动 deepin-reader并打开文档
   description: ''
   tags: []
   steps:
-  - action: mouse_click
+  - action: element_action
+    do: click
     ref: n16
     selector:
       name: Button_bookmark
-      role: check box
-  - action: mouse_click
+  - action: element_action
+    do: click
     ref: n22
     selector:
       name: Button_BookmarkAdd

--- a/tests/at/yaml/左侧栏 — 按钮切换/左侧栏 — 按钮切换.suite.yaml
+++ b/tests/at/yaml/左侧栏 — 按钮切换/左侧栏 — 按钮切换.suite.yaml
@@ -8,39 +8,38 @@ env_check: []
 setup:
 - action: session_start
   command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
-  wait: 3.0
+  wait: 6.0
 suites:
 - id: suite_sidebar_tabs_s1
   name: 启动 deepin-reader并打开文档
   description: ''
   tags: []
   steps:
-  - action: mouse_click
+  - action: element_action
+    do: click
     ref: n14
     selector:
       name: Button_thumbnail
-      role: check box
-  - action: mouse_click
+  - action: element_action
+    do: click
     ref: n15
     selector:
       name: Button_catalog
-      role: check box
-  - action: mouse_click
+  - action: element_action
+    do: click
     ref: n16
     selector:
       name: Button_bookmark
-      role: check box
-  - action: mouse_click
+  - action: element_action
+    do: click
     ref: n17
     selector:
       name: Button_annotation
-      role: check box
   assert_steps:
   - action: assert_element
     ref: n14
     selector:
       name: Button_thumbnail
-      role: check box
   - action: assert_element
     ref: n163
     selector:

--- a/tests/at/yaml/左侧栏 — 目录视图/左侧栏 — 目录视图.suite.yaml
+++ b/tests/at/yaml/左侧栏 — 目录视图/左侧栏 — 目录视图.suite.yaml
@@ -8,29 +8,19 @@ env_check: []
 setup:
 - action: session_start
   command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
-  wait: 3.0
+  wait: 6.0
 suites:
 - id: suite_sidebar_catalog_s1
   name: 启动 deepin-reader并打开文档
   description: ''
   tags: []
   steps:
-  - action: mouse_click
+  - action: element_action
+    do: click
     ref: n15
     selector:
       name: Button_catalog
-      role: check box
-  - action: mouse_click
-    ref: n163
-    selector:
-      name: View_CatalogTree
-      role: tree
   assert_steps:
-  - action: assert_element
-    ref: n163
-    selector:
-      name: View_CatalogTree
-      role: tree
   - action: assert_element
     ref: n163
     selector:

--- a/tests/at/yaml/左侧栏 — 缩略图视图/左侧栏 — 缩略图视图.suite.yaml
+++ b/tests/at/yaml/左侧栏 — 缩略图视图/左侧栏 — 缩略图视图.suite.yaml
@@ -8,19 +8,20 @@ env_check: []
 setup:
 - action: session_start
   command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
-  wait: 3.0
+  wait: 6.0
 suites:
 - id: suite_sidebar_thumbnails_s1
   name: 启动 deepin-reader并打开文档
   description: ''
   tags: []
   steps:
-  - action: mouse_click
+  - action: element_action
+    do: click
     ref: n14
     selector:
       name: Button_thumbnail
-      role: check box
-  - action: mouse_click
+  - action: element_action
+    do: click
     ref: n156
     selector:
       name: pageEdit

--- a/tests/at/yaml/标题栏搜索框/标题栏搜索框.suite.yaml
+++ b/tests/at/yaml/标题栏搜索框/标题栏搜索框.suite.yaml
@@ -24,11 +24,6 @@ suites:
     text: test
   - action: keyboard_press
     key: return
-  - action: mouse_click
-    ref: n244
-    selector:
-      name: DLineEditClearButton
-      role: button
   assert_steps:
   - action: assert_element
     ref: n243

--- a/tests/at/yaml/顶部标签页栏/顶部标签页栏.suite.yaml
+++ b/tests/at/yaml/顶部标签页栏/顶部标签页栏.suite.yaml
@@ -15,36 +15,13 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: mouse_click
-    ref: n213
-    selector:
-      name: DTabBarAddButton
-      role: button
-  - action: mouse_click
-    ref: n211
-    selector:
-      name: 向左滚动
-      role: button
-  - action: mouse_click
-    ref: n212
-    selector:
-      name: 向右滚动
-      role: button
+  - action: wait
+    seconds: 1.0
   assert_steps:
   - action: assert_element
     ref: n209
     selector:
       name: normal.pdf
       role: page tab list
-  - action: assert_element
-    ref: n211
-    selector:
-      name: 向左滚动
-      role: button
-  - action: assert_element
-    ref: n212
-    selector:
-      name: 向右滚动
-      role: button
 teardown:
 - action: session_stop


### PR DESCRIPTION
Stabilize Deepin Reader accessibility test suites by updating element definitions and pruning flaky interactions.

Tests:
- Adjust element roles and selectors in AT YAML to better reflect actual UI semantics and improve interaction stability.
- Reorganize and trim YAML suites for sidebar, menu, search, tab bar, and document interactions to reduce flakiness and ensure consistent AT-SPI-based testing.