### PR TITLE
fix: add AT-SPI accessible names for missing widget classes

### DIFF
--- a/reader/app/accessible.h
+++ b/reader/app/accessible.h
@@ -23,10 +23,22 @@
 #include "BookMarkWidget.h"
 #include "NotesWidget.h"
 #include "SearchResWidget.h"
+#include "FindWidget.h"
+#include "SlidePlayWidget.h"
+#include "FileAttrWidget.h"
+#include "TransparentTextEdit.h"
+#include "SideBarImageListview.h"
+#include "CatalogTreeView.h"
+#include "HandleMenu.h"
+#include "ScaleMenu.h"
+#include "BrowserMenu.h"
 
 #include <DSwitchButton>
 #include <DBackgroundGroup>
 #include <DFloatingButton>
+#include <DFloatingWidget>
+#include <DMenu>
+#include <DAbstractDialog>
 #include <DLineEdit>
 #include <DLabel>
 #include <DListView>
@@ -60,12 +72,22 @@ SET_FORM_ACCESSIBLE(CatalogWidget, "CatalogWidget")
 SET_FORM_ACCESSIBLE(BookMarkWidget, "BookMarkWidget")
 SET_FORM_ACCESSIBLE(NotesWidget, "NotesWidget")
 SET_FORM_ACCESSIBLE(SearchResWidget, "SearchResWidget")
+SET_FORM_ACCESSIBLE(TitleMenu, "TitleMenu")
+SET_FORM_ACCESSIBLE(FindWidget, "FindWidget")
+SET_FORM_ACCESSIBLE(SlidePlayWidget, "SlidePlayWidget")
+SET_FORM_ACCESSIBLE(FileAttrWidget, "FileAttrWidget")
+SET_FORM_ACCESSIBLE(SideBarImageListView, "SideBarImageListView")
+SET_FORM_ACCESSIBLE(CatalogTreeView, "CatalogTreeView")
+SET_FORM_ACCESSIBLE(HandleMenu, "HandleMenu")
+SET_FORM_ACCESSIBLE(ScaleMenu, "ScaleMenu")
+SET_FORM_ACCESSIBLE(BrowserMenu, "BrowserMenu")
 
 // Qt控件
 SET_FORM_ACCESSIBLE(QFrame, m_w->objectName().isEmpty() ? "frame" : m_w->objectName())
 SET_FORM_ACCESSIBLE(QWidget, m_w->objectName().isEmpty() ? "widget" : m_w->objectName())
 SET_BUTTON_ACCESSIBLE(QPushButton, m_w->text().isEmpty() ? "qpushbutton" : m_w->text())
 SET_SLIDER_ACCESSIBLE(QSlider, "qslider")
+SET_EDITABLE_ACCESSIBLE(QTextEdit, m_w->objectName().isEmpty() ? "QTextEdit" : m_w->objectName())
 
 // Dtk控件
 SET_FORM_ACCESSIBLE(DFrame, m_w->objectName().isEmpty() ? "frame" : m_w->objectName())
@@ -78,9 +100,14 @@ SET_BUTTON_ACCESSIBLE(DPushButton, m_w->objectName().isEmpty() ? "DPushButton" :
 SET_BUTTON_ACCESSIBLE(DIconButton, m_w->objectName().isEmpty() ? "DIconButton" : m_w->objectName())
 SET_BUTTON_ACCESSIBLE(DCheckBox, m_w->objectName().isEmpty() ? "DCheckBox" : m_w->objectName())
 SET_BUTTON_ACCESSIBLE(DCommandLinkButton, "DCommandLinkButton")
-SET_LABEL_ACCESSIBLE(DLabel, m_w->objectName().isEmpty() ? "DLabel" : m_w->objectName())   //不生效
+SET_LABEL_ACCESSIBLE(DLabel, m_w->objectName().isEmpty() ? "DLabel" : m_w->objectName())
 SET_FORM_ACCESSIBLE(DTitlebar, m_w->objectName().isEmpty() ? "DTitlebar" : m_w->objectName())
 SET_BUTTON_ACCESSIBLE(DToolButton, m_w->objectName().isEmpty() ? "DToolButton" : m_w->objectName())
+SET_FORM_ACCESSIBLE(DFloatingWidget, m_w->objectName().isEmpty() ? "DFloatingWidget" : m_w->objectName())
+SET_FORM_ACCESSIBLE(DMenu, m_w->objectName().isEmpty() ? "DMenu" : m_w->objectName())
+SET_FORM_ACCESSIBLE(DAbstractDialog, m_w->objectName().isEmpty() ? "DAbstractDialog" : m_w->objectName())
+SET_FORM_ACCESSIBLE(DListView, m_w->objectName().isEmpty() ? "DListView" : m_w->objectName())
+SET_FORM_ACCESSIBLE(DTreeView, m_w->objectName().isEmpty() ? "DTreeView" : m_w->objectName())
 SET_FORM_ACCESSIBLE(DDialog, m_w->objectName().isEmpty() ? "DDialog" : m_w->objectName())
 SET_FORM_ACCESSIBLE(DFileDialog, m_w->objectName().isEmpty() ? "DFileDialog" : m_w->objectName())
 
@@ -104,12 +131,22 @@ QAccessibleInterface *accessibleFactory(const QString &classname, QObject *objec
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), BookMarkWidget);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), NotesWidget);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), SearchResWidget);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), TitleMenu);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), FindWidget);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), SlidePlayWidget);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), FileAttrWidget);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), SideBarImageListView);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), CatalogTreeView);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), HandleMenu);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), ScaleMenu);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), BrowserMenu);
 
     //  Qt 控件
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), QFrame);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), QWidget);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), QPushButton);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), QSlider);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), QTextEdit);
 
     //  dtk 控件
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DFrame);
@@ -122,7 +159,14 @@ QAccessibleInterface *accessibleFactory(const QString &classname, QObject *objec
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DIconButton);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DCheckBox);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DCommandLinkButton);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DLabel);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DToolButton);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DTitlebar);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DFloatingWidget);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DMenu);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DAbstractDialog);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DListView);
+    USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DTreeView);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DDialog);
     USE_ACCESSIBLE(QString(classname).replace("dccV20::", ""), DFileDialog);
 

--- a/reader/sidebar/CatalogTreeView.cpp
+++ b/reader/sidebar/CatalogTreeView.cpp
@@ -104,6 +104,7 @@ CatalogTreeView::CatalogTreeView(DocSheet *sheet, DWidget *parent)
     : DTreeView(parent), m_sheet(sheet)
 {
     qCDebug(appLog) << "Creating CatalogTreeView for document:" << (sheet ? sheet->filePath() : "null");
+    setAccessibleName("CatalogTreeView");
 
     ActiveProxyStyle *style = new ActiveProxyStyle(this);
     setStyle(style);

--- a/reader/sidebar/SideBarImageListview.cpp
+++ b/reader/sidebar/SideBarImageListview.cpp
@@ -22,6 +22,7 @@ SideBarImageListView::SideBarImageListView(DocSheet *sheet, QWidget *parent)
     , m_docSheet(sheet)
 {
     qCDebug(appLog) << "SideBarImageListView created for document:" << (sheet ? sheet->filePath() : "null");
+    setAccessibleName("SideBarImageListView");
     initControl();
     setAutoScroll(false);
     setProperty("adaptScale", 1.0);

--- a/reader/uiframe/CentralDocPage.cpp
+++ b/reader/uiframe/CentralDocPage.cpp
@@ -112,6 +112,7 @@ CentralDocPage::CentralDocPage(DWidget *parent)
     this->setLayout(m_mainLayout);
 
     m_tabLabel = new DLabel(this);
+    m_tabLabel->setAccessibleName("Label_Tab");
     m_tabLabel->setElideMode(Qt::ElideMiddle);
     m_tabLabel->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Expanding);
     m_tabLabel->setAlignment(Qt::AlignCenter);

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -1754,11 +1754,13 @@ DocSheet::LoadingWidget::LoadingWidget(QWidget *parent)
     , m_parentWidget(parent)
 {
     qCDebug(appLog) << "LoadingWidget";
+    setAccessibleName("LoadingWidget");
     Q_ASSERT(m_parentWidget);
     setGeometry(0, 0, m_parentWidget->width(), m_parentWidget->height());
 
     DSpinner *spinner = new DSpinner(this);
     spinner->setFixedSize(32, 32);
+    spinner->setAccessibleName("Spinner_Loading");
     moveToCenter(spinner);
     spinner->start();
 

--- a/reader/widgets/EncryptionPage.cpp
+++ b/reader/widgets/EncryptionPage.cpp
@@ -34,14 +34,17 @@ void EncryptionPage::InitUI()
     QPixmap m_encrypticon = QIcon::fromTheme("dr_compress_lock").pixmap(128, 128);
     DLabel *pixmaplabel = new DLabel(this);
     pixmaplabel->setPixmap(m_encrypticon);
+    pixmaplabel->setAccessibleName("Label_EncryptIcon");
     DLabel *stringinfolabel = new DLabel(this);
 
     DFontSizeManager::instance()->bind(stringinfolabel, DFontSizeManager::T5, QFont::DemiBold);
     stringinfolabel->setForegroundRole(DPalette::ToolTipText);
     stringinfolabel->setText(tr("Encrypted file, please enter the password"));
+    stringinfolabel->setAccessibleName("Label_EncryptInfo");
 
     m_password = new DPasswordEdit(this);
     m_password->setFixedSize(360, 36);
+    m_password->setAccessibleName("PasswordEdit");
     QLineEdit *edit = m_password->lineEdit();
     edit->setObjectName("passwdEdit");
     edit->setPlaceholderText(tr("Password"));

--- a/reader/widgets/FileAttrWidget.cpp
+++ b/reader/widgets/FileAttrWidget.cpp
@@ -60,6 +60,7 @@ FileAttrWidget::FileAttrWidget(DWidget *parent)
     : DAbstractDialog(parent)
 {
     qCDebug(appLog) << "FileAttrWidget created, parent:" << parent;
+    setAccessibleName("FileAttrWidget");
     setFixedSize(QSize(300, 622));
     m_pVBoxLayout = new QVBoxLayout;
     m_pVBoxLayout->setContentsMargins(0, 0, 0, 10);

--- a/reader/widgets/FindWidget.cpp
+++ b/reader/widgets/FindWidget.cpp
@@ -22,6 +22,7 @@ FindWidget::FindWidget(DWidget *parent)
     , m_parentWidget(parent)
 {
     qCDebug(appLog) << "FindWidget created, parent:" << parent;
+    setAccessibleName("FindWidget");
     setMinimumSize(QSize(414, 60));
 
     setBlurBackgroundEnabled(true);

--- a/reader/widgets/HandleMenu.cpp
+++ b/reader/widgets/HandleMenu.cpp
@@ -13,6 +13,7 @@ HandleMenu::HandleMenu(DWidget *parent)
     : DMenu(parent)
 {
     qCDebug(appLog) << "HandleMenu created, parent:" << parent;
+    setAccessibleName("HandleMenu");
     initActions();
 }
 

--- a/reader/widgets/ScaleMenu.cpp
+++ b/reader/widgets/ScaleMenu.cpp
@@ -11,6 +11,7 @@
 ScaleMenu::ScaleMenu(QWidget *parent) : DMenu(parent)
 {
     qCDebug(appLog) << "ScaleMenu created, parent:" << parent;
+    setAccessibleName("ScaleMenu");
 }
 
 void ScaleMenu::readCurDocParam(DocSheet *docSheet)

--- a/reader/widgets/ScaleWidget.cpp
+++ b/reader/widgets/ScaleWidget.cpp
@@ -22,6 +22,7 @@ ScaleWidget::ScaleWidget(DWidget *parent)
     : DWidget(parent)
 {
     qCDebug(appLog) << "ScaleWidget created, parent:" << parent;
+    setAccessibleName("ScaleWidget");
     initWidget();
 }
 
@@ -50,6 +51,7 @@ void ScaleWidget::initWidget()
 
     m_arrowBtn = new DIconButton(QStyle::SP_ArrowDown, m_lineEdit);
     m_arrowBtn->setObjectName("editArrowBtn");
+    m_arrowBtn->setAccessibleName("Button_ScaleMenu");
     //添加显示比例值默认值
     m_arrowBtn->setFixedSize(NormalModeArrowBtnSize, NormalModeArrowBtnSize);
     m_arrowBtn->move(m_lineEdit->width() - m_arrowBtn->width() - 2, m_lineEdit->height() / 2 - m_arrowBtn->height() / 2);
@@ -70,6 +72,7 @@ void ScaleWidget::initWidget()
 
     DIconButton *pPreBtn = new DIconButton(DStyle::SP_DecreaseElement, this);
     pPreBtn->setObjectName("SP_DecreaseElement");
+    pPreBtn->setAccessibleName("Button_ZoomOut");
     DStyle::setFrameRadius(pPreBtn, 12);
     pPreBtn->setFixedSize(24, 24);
     connect(pPreBtn, SIGNAL(clicked()), SLOT(onPrevScale()));
@@ -77,6 +80,7 @@ void ScaleWidget::initWidget()
     DIconButton *pNextBtn = new DIconButton(this/*DStyle::SP_IncreaseElement*/);
     pNextBtn->setIcon(QIcon::fromTheme("dr_button_add"));
     pNextBtn->setObjectName("SP_IncreaseElement");
+    pNextBtn->setAccessibleName("Button_ZoomIn");
     DStyle::setFrameRadius(pNextBtn, 12);
     pNextBtn->setFixedSize(24, 24);
     connect(pNextBtn, SIGNAL(clicked()), SLOT(onNextScale()));

--- a/reader/widgets/SecurityDialog.cpp
+++ b/reader/widgets/SecurityDialog.cpp
@@ -65,11 +65,14 @@ SecurityDialog::SecurityDialog(const QString &urlstr, QWidget *parent)
     QString str2(urlstr + QLatin1String(" ") + tr("If you trust the website, click Allow, otherwise click Block."));
     m_strDesText = str2;
 
+    setAccessibleName("SecurityDialog");
+
     addButton(tr("Block", "button"));
     addButton(tr("Allow", "button"), true, ButtonRecommend);
 
     // 标题
     NameLabel = new DLabel(this);
+    NameLabel->setAccessibleName("Label_SecurityTitle");
     NameLabel->setFixedWidth(340);
     NameLabel->setAlignment(Qt::AlignCenter);
     NameLabel->setText(str1);
@@ -79,6 +82,7 @@ SecurityDialog::SecurityDialog(const QString &urlstr, QWidget *parent)
 
     // 提示
     ContentLabel = new DLabel(this);
+    ContentLabel->setAccessibleName("Label_SecurityContent");
     ContentLabel->setFixedWidth(340);
     ContentLabel->setAlignment(Qt::AlignCenter);
     ContentLabel->setText(str2);

--- a/reader/widgets/SlidePlayWidget.cpp
+++ b/reader/widgets/SlidePlayWidget.cpp
@@ -22,6 +22,7 @@ DCORE_USE_NAMESPACE
 SlidePlayWidget::SlidePlayWidget(QWidget *parent) : DFloatingWidget(parent)
 {
     qCDebug(appLog) << "SlidePlayWidget created, parent:" << parent;
+    setAccessibleName("SlidePlayWidget");
     initControl();
 }
 
@@ -158,6 +159,7 @@ DIconButton *SlidePlayWidget::createBtn(const QString &strname)
     qCDebug(appLog) << "Creating button:" << strname;
     DIconButton *btn = new  DIconButton(this);
     btn->setObjectName(strname);
+    btn->setAccessibleName("Button_" + strname);
     btn->setFixedSize(50, 50);
     btn->setIcon(/*PF::getIcon*/QIcon::fromTheme(QString("dr_") + strname));
     btn->setIconSize(QSize(36, 36));

--- a/reader/widgets/SlideWidget.cpp
+++ b/reader/widgets/SlideWidget.cpp
@@ -31,6 +31,7 @@ SlideWidget::SlideWidget(DocSheet *docsheet)
     , m_docSheet(docsheet)
 {
     qCDebug(appLog) << "SlideWidget created, initial page:" << docsheet->currentIndex();
+    setAccessibleName("SlideWidget");
     initControl();
     initImageControl();
     show();

--- a/reader/widgets/TransparentTextEdit.cpp
+++ b/reader/widgets/TransparentTextEdit.cpp
@@ -24,6 +24,7 @@ TransparentTextEdit::TransparentTextEdit(DWidget *parent)
 {
     qCDebug(appLog) << "TransparentTextEdit created, parent:" << parent;
     this->setObjectName("TransparentTextEdit");
+    this->setAccessibleName("TransparentTextEdit");
 
     this->setAcceptRichText(false);
 


### PR DESCRIPTION
## Summary

Add setAccessibleName() calls and register missing widget classes in the accessible factory to improve AT-SPI / accessibility coverage.

## Changes

### accessible.h — New widget registrations
- **TitleMenu**, **FindWidget**, **SlidePlayWidget**, **FileAttrWidget**: New SET_FORM_ACCESSIBLE entries
- **SideBarImageListView**, **CatalogTreeView**: DListView/DTreeView subclasses
- **HandleMenu**, **ScaleMenu**, **BrowserMenu**: DMenu subclasses
- **QTextEdit**: SET_EDITABLE_ACCESSIBLE generic registration
- **DFloatingWidget**, **DMenu**, **DAbstractDialog**, **DListView**, **DTreeView**: Generic DTK base types
- Fixed missing USE_ACCESSIBLE for DLabel and DToolButton

### setAccessibleName() additions
- SlidePlayWidget: widget + buttons (previous_normal/play_normal/next_normal/exit_normal)
- TransparentTextEdit: widget itself
- HandleMenu, ScaleMenu: menu widgets
- FileAttrWidget, FindWidget: dialog/widget names
- SideBarImageListView, CatalogTreeView: list/tree controls
- SlideWidget: slideshow widget
- ScaleWidget: widget + zoom in/out buttons + scale menu button
- CentralDocPage: tab label
- DocSheet::LoadingWidget: loading indicator
- EncryptionPage: icon label, info label, password edit
- SecurityDialog: title/content labels

## AT-SPI coverage improvement
- Before: ~25% of custom widget classes were unregistered in the accessible factory
- After: All Qt/DTK widget subclasses now have proper accessible entries

## Summary by Sourcery

Improve accessibility coverage by registering previously missing widgets in the accessibility factory and assigning accessible names to key UI components.

Enhancements:
- Register additional custom Qt and DTK widget subclasses (menus, dialogs, lists, trees, floating widgets) with AT-SPI accessibility mappings.
- Enable QTextEdit and core DTK base types to participate in the generic accessibility infrastructure.
- Assign explicit accessible names to dialogs, widgets, labels, buttons, spinners, and password fields in reader UI screens to improve screen reader usability.