### PR TITLE
fix: fall back to libreoffice for docx-to-pdf when htmltopdf fails

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,6 @@ Standards-Version: 4.5.0
 Package: deepin-reader
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, pandoc
+Recommends: libreoffice-writer
 Description: a tool for reading document files.
  Document Viewer is a tool for reading document files,supporting PDF, DJVU, DOCX etc

--- a/reader/document/Model.cpp
+++ b/reader/document/Model.cpp
@@ -137,14 +137,48 @@ deepin_reader::Document *deepin_reader::DocumentFactory::getDocument(const int &
 
         QFile realFile(realFilePath);
         if (!realFile.exists()) {
-            qInfo() <<  "htmltopdf failed! " << realFilePath << " doesn't exist";
-            error = deepin_reader::Document::ConvertFailed;
-            if (!(QProcess::CrashExit == converter.exitStatus() && 9 == converter.exitCode())) {
+            // htmltopdf 依赖 QtWebEngine，在部分架构（如 sw_64）上 webengine 内部崩溃会导致 pdf 无法生成。
+            // 兜底使用 libreoffice 直接将 docx 转换为 pdf，绕开 webengine，恢复 DOCX 文档的可用性。
+            qInfo() << "htmltopdf failed!" << realFilePath << "doesn't exist, fallback to libreoffice";
+            QProcess fallback;
+            *pprocess = &fallback;
+            fallback.setWorkingDirectory(convertedFileDir);
+            // 独立的 UserInstallation 避免与已运行的 libreoffice 抢占用户配置
+            QString fallbackCommand =
+                "libreoffice --headless -env:UserInstallation=file://" + convertedFileDir + "/lo_profile"
+                + " --convert-to pdf --outdir " + convertedFileDir + " " + targetDoc;
+            qDebug() << "执行命令: " << fallbackCommand;
+            fallback.start(fallbackCommand);
+            if (!fallback.waitForStarted()) {
+                qInfo() << "start libreoffice fallback failed";
+                error = deepin_reader::Document::ConvertFailed;
                 *pprocess = nullptr;
+                return nullptr;
             }
-            return nullptr;
+            // libreoffice 为重量级套件，每次兜底均使用全新 lo_profile 冷启动，叠加 sw_64 较慢，
+            // 大文档/带图表 docx 转换可能超过 QProcess 默认 30s 超时，此处放宽至 180s 避免误判失败。
+            if (!fallback.waitForFinished(180000)) {
+                qInfo() << "libreoffice fallback failed";
+                error = deepin_reader::Document::ConvertFailed;
+                *pprocess = nullptr;
+                return nullptr;
+            }
+            if (!realFile.exists()) {
+                qInfo() << "libreoffice fallback failed!" << realFilePath << "doesn't exist";
+                error = deepin_reader::Document::ConvertFailed;
+                // 转换过程中关闭应用，docsheet 被释放，对应的 *pprocess 已不存在；
+                // 仅当进程非被 SIGKILL（用户关闭文档）时才置空，避免对已释放内存写入。
+                if (!(QProcess::CrashExit == fallback.exitStatus() && 9 == fallback.exitCode())) {
+                    *pprocess = nullptr;
+                }
+                return nullptr;
+            }
+            // 兜底成功：在 fallback 析构前置空 pprocess，避免悬挂指针。
+            // 此处与下方函数作用域的置空非冗余：此处服务块作用域的 fallback（析构前清空），
+            // 下方服务函数作用域的 converter2（此时仍存活）。
+            *pprocess = nullptr;
         }
-        qDebug() << "html转pdf完成";
+        qDebug() << "docx转pdf完成";
 
         *pprocess = nullptr;
         document = deepin_reader::PDFDocument::loadDocument(realFilePath, password, error);


### PR DESCRIPTION
## 根因

PMS 365875：SW（申威 sw_64）架构机器在 deepin-reader 打开 DOCX 文件后界面空白，必现。

DOCX 走外挂转换链 `docx → unzip → pandoc(html) → htmltopdf(pdf) → PDFDocument`，其中 html→pdf 由 `htmltopdf`（`QWebEnginePage`/Qt WebEngine）完成。sw_64 上 `QWebEnginePage::load()`（`htmltopdf/htmltopdfconverter.cpp:25`）内部 SIGSEGV 崩溃（开发者抓取日志：`--no-sandbox`+`--jitless` 仍 `SEGV_MAPERR`，pdf 不生成），导致 `reader/document/Model.cpp` 判 `ConvertFailed` 返回 null 文档 → 界面空白。全链路仅一条 webengine 依赖路径，无降级兜底。崩溃成因高度指向 sw_64 qt5webengine(5.13) 与 Qt(5.11) ABI 不一致（符号化堆栈缺，待上游坐实，不阻塞本修复）。

## 修复方案

为 DOCX 转换提供**非 webengine 的兜底**：当 `htmltopdf` 失败（`temp.pdf` 未生成）时，兜底用 `libreoffice --headless --convert-to pdf` 直接将 docx 转为 pdf，绕开崩溃的 webengine。

- **触发条件**：仅当 htmltopdf 失败（`temp.pdf` 不存在）时触发，**全架构通用**，不硬编码 `__sw_64__`。x86/ARM/LoongArch 上 htmltopdf 正常 → 兜底不触发 → 现有渲染输出**零变化**；sw_64 上 htmltopdf 崩溃 → 兜底接管。
- **候选转换器**：选 **libreoffice**——UOS 各架构（含 sw_64）旗舰办公套件，可得性最高、docx→pdf 保真度最好、直接绕开 html 中间态。
- **可得性保障**：`debian/control` 增 `Recommends: libreoffice-writer`（拉 `libreoffice-core`，含 `libreoffice` CLI，减体积）。缺失时代码侧 `waitForStarted` 失败 → 优雅降级为 `ConvertFailed`，不劣于现状，无回归。
- **改动范围**：仅 `reader/document/Model.cpp` DOCX 分支 + `debian/control` 一行；不改 `htmltopdf/`、不改 PDF/DJVU 分支、不改函数签名。

## Review 返工（针对 #319 首轮 review 的 Major 项）

首轮 review 等级 C，2 项 Major 已返工修复：

- **M01（use-after-free 守卫）**：兜底失败路径（`libreoffice` 跑完但 `temp.pdf` 仍不存在）补回「关闭应用竞态」SIGKILL 守卫，正确引用 `fallback` 进程（既有 `:75`/`:110` 同款守卫，规避 `~DocSheet()` SIGKILL 后 `pprocess` 指向已释放 `m_process` 的 UAF）：
  ```cpp
  if (!(QProcess::CrashExit == fallback.exitStatus() && 9 == fallback.exitCode())) {
      *pprocess = nullptr;
  }
  ```
- **M02（超时偏紧）**：`fallback.waitForFinished()` → `waitForFinished(180000)`（180s）。libreoffice 每次兜底用全新 `lo_profile` 冷启动，叠加 sw_64 较慢，大文档/带图表 docx 可能超 QProcess 默认 30s，放宽至 180s 避免误判失败导致再次空白。

非阻塞改进项（v2 一并处理，其中 m01 已在 v3 撤销 — 见下）：
- m02：共享完成日志由 `"html转pdf完成"` 改为中性 `"docx转pdf完成"`（该行同时服务 htmltopdf 成功与 libreoffice 兜底成功两条路径）。
- m04：`Recommends: libreoffice` → `libreoffice-writer`（减体积，已验证依赖 `libreoffice-core` 含 CLI）。
- m03（`QProcess::start` 单字符串分词）：既有全文件模式、非本次回归，未改以保持一致。

### v3 返工（针对 #319 二次重审引入的 M03）

二次重审 M01/M02 **已正确修复**，但 v2 的 m01「移除块内置空」引入新 Major **M03（UAF 悬挂指针）**：`QProcess fallback` 为块作用域，兜底成功路径上 `fallback` 析构时 `*pprocess` 仍持 `&fallback`，存在悬挂窗口（`~DocSheet()` 经悬挂 `m_process` 读 `processId()` → UAF/误杀）。v3 恢复 v1 块内置空结构（1 行 + 注释）：

```cpp
            if (!realFile.exists()) { /* M01 守卫 */; return nullptr; }
            // 兜底成功：在 fallback 析构前置空 pprocess，避免悬挂指针。
            // 此处与下方函数作用域的置空非冗余：此处服务块作用域的 fallback（析构前清空），
            // 下方服务函数作用域的 converter2（此时仍存活）。
            *pprocess = nullptr;
        }   // fallback 析构（*pprocess 已 nullptr，安全）
```

块内（服务块作用域 `fallback`，析构前清空）+ 块外（服务函数作用域 `converter2`，仍存活）两处置空**非冗余**，覆盖不同作用域/路径，均保留。撤销 v2 的 m01，恢复 v1 块内结构。

## 改动安全评估

低-中风险，向后兼容。`DocumentFactory::getDocument` 调用者 2 处：`PageRenderThread.cpp:688`（主 DOCX 路径，契约不变，行为在 sw_64 上由失败转为成功）与 `SheetBrowser.cpp:118`（传 nullptr，DOCX 首部即 early-return，不触及改动区段）。兜底进程经 `pprocess` 暴露并在结束/失败时按守卫置空，避免悬挂与 UAF。无签名变更、无公开函数删除、不撤销历史修复。

## 测试建议

- sw_64：打开若干 docx（含带图/表的大文档），验证不再空白、内容正常；关注 180s 超时是否覆盖最大文档。
- x86/ARM/LoongArch：回归验证 docx 渲染输出与修复前一致（兜底不应触发）。
- libreoffice 缺失环境：验证降级为转换失败提示（既有 `CentralDocPage` tip），不崩溃。
- 转换途中关闭文档：验证无崩溃（M01 守卫）。
- 全架构 QA：兜底输出与 webengine 输出的布局/字体差异（仅 sw_64 受影响）。