### PR TITLE
refactor(tests): auto-discover reader sources and include dirs

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,49 +75,38 @@ endif()
 set(XPS_SUPPORT_ENABLED ${XPS_SUPPORT_RESOLVED})
 
 # ====== 收集 reader 源文件 ======
-# 根目录源文件（排除 main.cpp）
-file(GLOB READER_ROOT_SOURCES
+# 递归收集 reader/ 下所有源文件，排除 main.cpp
+# 新增子模块时无需修改此文件
+file(GLOB_RECURSE READER_ALL_SOURCES
     "${CMAKE_SOURCE_DIR}/reader/*.cpp"
     "${CMAKE_SOURCE_DIR}/reader/*.c"
     "${CMAKE_SOURCE_DIR}/reader/*.h"
 )
-list(REMOVE_ITEM READER_ROOT_SOURCES "${CMAKE_SOURCE_DIR}/reader/main.cpp")
+list(REMOVE_ITEM READER_ALL_SOURCES "${CMAKE_SOURCE_DIR}/reader/main.cpp")
 
-# 各子模块源文件
-file(GLOB_RECURSE APP_SOURCES     "${CMAKE_SOURCE_DIR}/reader/app/*.cpp" "${CMAKE_SOURCE_DIR}/reader/app/*.h")
-file(GLOB_RECURSE BROWSER_SOURCES "${CMAKE_SOURCE_DIR}/reader/browser/*.cpp" "${CMAKE_SOURCE_DIR}/reader/browser/*.h")
-file(GLOB_RECURSE DOCUMENT_SOURCES "${CMAKE_SOURCE_DIR}/reader/document/*.cpp" "${CMAKE_SOURCE_DIR}/reader/document/*.h")
-file(GLOB_RECURSE SIDEBAR_SOURCES "${CMAKE_SOURCE_DIR}/reader/sidebar/*.cpp" "${CMAKE_SOURCE_DIR}/reader/sidebar/*.h")
-file(GLOB_RECURSE UIFRAME_SOURCES "${CMAKE_SOURCE_DIR}/reader/uiframe/*.cpp" "${CMAKE_SOURCE_DIR}/reader/uiframe/*.h")
-file(GLOB_RECURSE WIDGET_SOURCES  "${CMAKE_SOURCE_DIR}/reader/widgets/*.cpp" "${CMAKE_SOURCE_DIR}/reader/widgets/*.h")
+# ====== 自动发现 reader 子目录作为 include 路径 ======
+file(GLOB READER_SUBDIRS LIST_DIRECTORIES true "${CMAKE_SOURCE_DIR}/reader/*")
+foreach(_dir ${READER_SUBDIRS})
+    if(IS_DIRECTORY "${_dir}")
+        list(APPEND READER_INCLUDE_DIRS "${_dir}")
+    endif()
+endforeach()
+list(APPEND READER_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/reader")
 
 # ====== 收集测试源文件 ======
-file(GLOB TEST_ROOT_SOURCES
+file(GLOB_RECURSE TEST_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
 )
-file(GLOB TEST_APP_SOURCES     "${CMAKE_CURRENT_SOURCE_DIR}/app/*.cpp")
-file(GLOB TEST_BROWSER_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/browser/*.cpp")
-file(GLOB TEST_DOCUMENT_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/document/*.cpp")
-file(GLOB TEST_SIDEBAR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/sidebar/*.cpp")
-file(GLOB TEST_UIFRAME_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/uiframe/*.cpp")
-file(GLOB TEST_WIDGET_SOURCES  "${CMAKE_CURRENT_SOURCE_DIR}/widgets/*.cpp")
+# 排除非测试辅助目录（如 at/、files/ 等资源目录）
+list(FILTER TEST_SOURCES EXCLUDE REGEX "${CMAKE_CURRENT_SOURCE_DIR}/at/")
+list(FILTER TEST_SOURCES EXCLUDE REGEX "${CMAKE_CURRENT_SOURCE_DIR}/files/")
+list(FILTER TEST_SOURCES EXCLUDE REGEX "${CMAKE_CURRENT_SOURCE_DIR}/include/")
 
 # ====== 合并所有源文件 ======
 set(ALL_SOURCES
-    ${READER_ROOT_SOURCES}
-    ${APP_SOURCES}
-    ${BROWSER_SOURCES}
-    ${DOCUMENT_SOURCES}
-    ${SIDEBAR_SOURCES}
-    ${UIFRAME_SOURCES}
-    ${WIDGET_SOURCES}
-    ${TEST_ROOT_SOURCES}
-    ${TEST_APP_SOURCES}
-    ${TEST_BROWSER_SOURCES}
-    ${TEST_DOCUMENT_SOURCES}
-    ${TEST_SIDEBAR_SOURCES}
-    ${TEST_UIFRAME_SOURCES}
-    ${TEST_WIDGET_SOURCES}
+    ${READER_ALL_SOURCES}
+    ${TEST_SOURCES}
 )
 
 # ====== 定义测试可执行文件 ======
@@ -130,14 +119,9 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 
 # ====== 包含目录 ======
+# READER_INCLUDE_DIRS 由上方自动发现，新增子模块时无需手动添加
 target_include_directories(${PROJECT_NAME} PUBLIC
-    ${CMAKE_SOURCE_DIR}/reader
-    ${CMAKE_SOURCE_DIR}/reader/app
-    ${CMAKE_SOURCE_DIR}/reader/browser
-    ${CMAKE_SOURCE_DIR}/reader/document
-    ${CMAKE_SOURCE_DIR}/reader/sidebar
-    ${CMAKE_SOURCE_DIR}/reader/uiframe
-    ${CMAKE_SOURCE_DIR}/reader/widgets
+    ${READER_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/include/gtest
     ${PDFIUM_INCLUDE_DIRS}


### PR DESCRIPTION
## 修改内容

将 tests/CMakeLists.txt 中源文件收集和 include 目录配置从逐个手动列举改为自动扫描发现：

- **reader 源文件**：用一条 `GLOB_RECURSE` 递归收集 `reader/` 下全部源文件，排除 `main.cpp`
- **reader include 目录**：自动扫描 `reader/` 下所有一级子目录，全部加入 include path
- **测试源文件**：用一条 `GLOB_RECURSE` 收集测试源文件，`FILTER EXCLUDE` 排除辅助目录

## 效果

以后在 `reader/` 下新增任何子模块（如 `reader/newmodule/`），`tests/CMakeLists.txt` 不再需要任何修改——新模块的头文件路径和源文件会被自动发现。

## 测试

运行 `./tests/test-prj-running.sh`，编译通过，1057 个测试全部通过，覆盖率 82.7% 不变。

## Summary by Sourcery

将测试工程的源文件与头文件目录配置改为自动发现，以便新 reader 子模块无需修改 CMake 配置即可纳入测试构建。

Enhancements:
- 自动递归发现 reader 源文件并排除入口文件。
- 自动将 reader 一级子目录加入头文件搜索路径。
- 自动递归发现测试源文件并排除辅助资源目录。

Build:
- 简化 tests/CMakeLists.txt 中的源文件和 include 目录配置，新增 reader 子模块无需手动更新构建配置。