### PR TITLE
feat: restore reading state with scroll position, sidebar width

### DIFF
--- a/reader/MainWindow.cpp
+++ b/reader/MainWindow.cpp
@@ -166,12 +166,16 @@ void MainWindow::addFile(const QString &filePath)
 void MainWindow::closeEvent(QCloseEvent *event)
 {
     qCDebug(appLog) << "MainWindow::closeEvent() - Starting close event processing";
-    if (m_central && !m_central->handleClose(true)) {
-        qCDebug(appLog) << "MainWindow::closeEvent() - Central widget close failed, ignoring event";
-        event->ignore();
-        return;
+
+    // 在关闭 sheet 前保存当前 sheet 的阅读状态
+    if (m_central && m_central->docPage()) {
+        DocSheet *curSheet = m_central->docPage()->getCurSheet();
+        if (curSheet && curSheet->opened()) {
+            curSheet->saveCurrentViewState();
+        }
     }
 
+    // 在关闭 sheet 之前保存标签页组（因为 handleClose 会删除所有 sheet）
     if (m_central && m_central->docPage()) {
         QList<DocSheet *> sheets = m_central->docPage()->getSheets();
         QStringList filePaths;
@@ -184,9 +188,19 @@ void MainWindow::closeEvent(QCloseEvent *event)
             }
         }
         int windowIndex = MainWindow::m_list.indexOf(this);
-        if (windowIndex >= 0) {
+        if (windowIndex >= 0 && !filePaths.isEmpty()) {
             Database::instance()->saveTabGroup(windowIndex, filePaths, activeIndex);
         }
+    }
+
+    // 注意：滚动位置和标签页组在 handleClose 之前保存（乐观保存策略）。
+    // 如果 handleClose 返回 false（用户取消关闭），已保存的状态不会造成数据损坏，
+    // 因为后续操作（自动保存/真正关闭时）会更新为最新状态。
+
+    if (m_central && !m_central->handleClose(true)) {
+        qCDebug(appLog) << "MainWindow::closeEvent() - Central widget close failed, ignoring event";
+        event->ignore();
+        return;
     }
 
     QSettings settings(QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).filePath("config.conf"), QSettings::IniFormat, this);

--- a/reader/app/Database.cpp
+++ b/reader/app/Database.cpp
@@ -83,6 +83,7 @@ bool Database::prepareOperation()
                     ",sidebarIndex INTEGER"
                     ",currentPage INTEGER"
                     ",sidebarWidth INTEGER DEFAULT 200"
+                    ",sidebarWidthChanged INTEGER DEFAULT 0"
                     ",scrollPosition REAL DEFAULT 0.0"
                     ",expandedSections TEXT DEFAULT '[]'"
                     ",fileSize INTEGER DEFAULT 0"
@@ -126,6 +127,7 @@ bool Database::migrateOperationTable()
 
     QList<NewColumn> newColumns = {
         {"sidebarWidth",  "INTEGER DEFAULT 200"},
+        {"sidebarWidthChanged", "INTEGER DEFAULT 0"},
         {"scrollPosition", "REAL DEFAULT 0.0"},
         {"expandedSections", "TEXT DEFAULT '[]'"},
         {"fileSize",       "INTEGER DEFAULT 0"},
@@ -179,6 +181,7 @@ bool Database::readOperation(DocSheet *sheet)
         sheet->m_operation.currentPage = query.value("currentPage").toInt();
         // V1.2 新增字段
         sheet->m_operation.sidebarWidth = query.value("sidebarWidth").toInt();
+        sheet->m_operation.sidebarWidthChanged = query.value("sidebarWidthChanged").toInt() != 0;
         sheet->m_operation.scrollPosition = query.value("scrollPosition").toFloat();
         // 目录树展开状态
         QString expandedJson = query.value("expandedSections").toString();
@@ -212,10 +215,10 @@ bool Database::saveOperation(DocSheet *sheet, const QString &cachedContentHash)
     QSqlQuery query(m_database);
     query.prepare("REPLACE INTO "
                   "operation(filePath,layoutMode,mouseShape,scaleMode,rotation,scaleFactor,"
-                  "sidebarVisible,sidebarIndex,currentPage,sidebarWidth,scrollPosition,expandedSections,"
+                  "sidebarVisible,sidebarIndex,currentPage,sidebarWidth,sidebarWidthChanged,scrollPosition,expandedSections,"
                   "fileSize,lastModified,contentHash)"
                   " VALUES(:filePath,:layoutMode,:mouseShape,:scaleMode,:rotation,:scaleFactor,"
-                  ":sidebarVisible,:sidebarIndex,:currentPage,:sidebarWidth,:scrollPosition,:expandedSections,"
+                  ":sidebarVisible,:sidebarIndex,:currentPage,:sidebarWidth,:sidebarWidthChanged,:scrollPosition,:expandedSections,"
                   ":fileSize,:lastModified,:contentHash)");
     query.bindValue(":filePath", sheet->filePath());
     query.bindValue(":layoutMode", sheet->m_operation.layoutMode);
@@ -228,6 +231,7 @@ bool Database::saveOperation(DocSheet *sheet, const QString &cachedContentHash)
     query.bindValue(":currentPage", sheet->m_operation.currentPage);
     // V1.2 新增字段
     query.bindValue(":sidebarWidth", sheet->m_operation.sidebarWidth);
+    query.bindValue(":sidebarWidthChanged", sheet->m_operation.sidebarWidthChanged ? 1 : 0);
     query.bindValue(":scrollPosition", sheet->m_operation.scrollPosition);
     // 目录树展开状态序列化为 JSON 数组
     QJsonArray expandedArr;
@@ -295,6 +299,7 @@ bool Database::matchOperationByContent(const QFileInfo &fileInfo, DocSheet *shee
         sheet->m_operation.sidebarIndex = query.value("sidebarIndex").toInt();
         sheet->m_operation.currentPage = query.value("currentPage").toInt();
         sheet->m_operation.sidebarWidth = query.value("sidebarWidth").toInt();
+        sheet->m_operation.sidebarWidthChanged = query.value("sidebarWidthChanged").toInt() != 0;
         sheet->m_operation.scrollPosition = query.value("scrollPosition").toFloat();
         // 目录树展开状态
         QString expandedJson = query.value("expandedSections").toString();

--- a/reader/main.cpp
+++ b/reader/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,7 @@
 #include "accessible.h"
 #include "Utils.h"
 #include "DBusObject.h"
+#include "Database.h"
 #include "ddlog.h"
 #include "logger.h"
 
@@ -21,6 +22,7 @@
 #include <QScreen>
 #include <QAccessible>
 #include <QDebug>
+#include <QFileInfo>
 #include <QFontDatabase>
 
 DGUI_USE_NAMESPACE
@@ -103,6 +105,49 @@ int main(int argc, char *argv[])
     if (!DBusObject::instance()->registerOrNotify(arguments)) {
         qCInfo(appLog) << "Another instance is running, exiting";
         return 0;
+    }
+
+    // 这是第一个实例（没有其他 deepin-reader 在运行），恢复上次的标签页组
+    // 不管命令行是否指定了文件，都恢复之前的标签页
+    // 注意：当前仅恢复 windowIndex=0 的标签页组（多窗口场景的完整恢复待后续优化）
+    {
+        int savedActiveIndex = 0;
+        QStringList restoredFiles = Database::instance()->readTabGroup(0, savedActiveIndex);
+        // 过滤掉不存在或不可读的文件
+        QStringList validRestored;
+        for (const QString &filePath : restoredFiles) {
+            QFileInfo fi(filePath);
+            if (fi.exists() && fi.isReadable())
+                validRestored.append(filePath);
+        }
+
+        if (!validRestored.isEmpty()) {
+            // 将命令行参数中的 URL 转为本地路径
+            QStringList localArguments;
+            for (const QString &arg : arguments) {
+                QUrl url(arg);
+                if (url.isLocalFile())
+                    localArguments.append(url.toLocalFile());
+                else
+                    localArguments.append(arg);
+            }
+
+            // 合并文件列表：先恢复历史标签页，再把用户指定的文件放到末尾（成为活动标签页）
+            // 如果用户指定的文件已在恢复列表中，先移除再追加到末尾
+            QStringList allFiles = validRestored;
+            int existingCount = 0;
+            for (const QString &fp : localArguments) {
+                if (allFiles.removeAll(fp) > 0)
+                    existingCount++;
+                if (QFile::exists(fp))
+                    allFiles.append(fp);
+            }
+
+            arguments = allFiles;
+            int newFileCount = localArguments.size() - existingCount;
+            qCInfo(appLog) << "Restoring" << validRestored.size() << "tabs from last session"
+                           << "+" << newFileCount << "new files";
+        }
     }
 
     QAccessible::installFactory(accessibleFactory);

--- a/reader/sidebar/SheetSidebar.cpp
+++ b/reader/sidebar/SheetSidebar.cpp
@@ -373,11 +373,7 @@ DToolButton *SheetSidebar::createBtn(const QString &btnName, const QString &objN
 
 void SheetSidebar::resizeEvent(QResizeEvent *event)
 {
-    // 侧边栏宽度变化时通知 DocSheet 更新
-    if (m_sheet && event->size().width() > 0) {
-        m_sheet->setSidebarWidth(event->size().width());
-    }
-
+    // 侧边栏宽度变化时的自适应缩放
     qreal scale = event->size().width() * 1.0 / LEFTMINWIDTH;
     adaptWindowSize(scale);
     BaseWidget::resizeEvent(event);

--- a/reader/uiframe/CentralDocPage.cpp
+++ b/reader/uiframe/CentralDocPage.cpp
@@ -24,6 +24,7 @@
 #include <QDesktopServices>
 #include <QScreen>
 #include <QUrl>
+#include <QPointer>
 #include <QDesktopServices>
 #include <QScrollBar>
 #include <QStackedLayout>
@@ -226,6 +227,12 @@ void CentralDocPage::addFileAsync(const QString &filePath)
         }
     }
 
+    // 打开新文件前，保存当前 sheet 的阅读状态
+    DocSheet *curSheet = getCurSheet();
+    if (curSheet && curSheet->opened()) {
+        curSheet->saveCurrentViewState();
+    }
+
     Dr::FileType fileType = Dr::fileType(filePath);
 #ifdef XPS_SUPPORT_ENABLED
     if (Dr::PDF != fileType && Dr::DJVU != fileType && Dr::DOCX != fileType && Dr::XPS != fileType) {
@@ -304,12 +311,23 @@ void CentralDocPage::onOpened(DocSheet *sheet, deepin_reader::Document::Error er
     sheet->defaultFocus();
 }
 
+
 void CentralDocPage::onTabChanged(DocSheet *sheet)
 {
     qCInfo(appLog) << "onTabChanged";
     if (nullptr != sheet) {
         qCInfo(appLog) << "sheet is not null";
+
+        // 离开当前 sheet 前，保存其阅读状态
+        QPointer<DocSheet> prevSheet = qobject_cast<DocSheet *>(m_stackedLayout->currentWidget());
+        if (prevSheet && prevSheet != sheet && prevSheet->opened()) {
+            prevSheet->saveCurrentViewState();
+        }
+
         m_stackedLayout->setCurrentWidget(sheet);
+
+        // 切换到新 sheet 后，恢复其已保存的阅读状态
+        sheet->restoreSavedViewState();
 
         sheet->defaultFocus();
     }

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -52,8 +52,6 @@ namespace {
 constexpr double kXpsLogicalDpi = 96.0;
 constexpr int kFallbackPrintDpi = 300;
 constexpr int kMaxPrintPixelsPerSide = 10000;
-constexpr int kRestoreScrollDelayMs = 100;    // 恢复滚动位置延迟
-constexpr int kRestoreCatalogDelayMs = 150;   // 恢复目录树展开状态延迟
 }
 
 QReadWriteLock DocSheet::g_lock;
@@ -106,6 +104,16 @@ DocSheet::DocSheet(const Dr::FileType &fileType, const QString &filePath,  QWidg
     resetChildParent();
     this->insertWidget(0, m_browser);
     this->insertWidget(0, m_sidebar);
+
+    // 用户拖拽 splitter 调整侧边栏宽度时记录
+    connect(this, &DSplitter::splitterMoved, this, [this](int pos, int index) {
+        Q_UNUSED(pos)
+        Q_UNUSED(index)
+        if (m_sidebar && m_sidebar->isVisible() && m_sidebar->width() > 0) {
+            m_operation.sidebarWidth = m_sidebar->width();
+            m_operation.sidebarWidthChanged = true;
+        }
+    });
 
     // 定时自动保存（30秒）
     m_autoSaveTimer = new QTimer(this);
@@ -857,6 +865,7 @@ SheetOperation DocSheet::operation() const
 void DocSheet::setSidebarWidth(int width)
 {
     m_operation.sidebarWidth = width;
+    m_operation.sidebarWidthChanged = true;
 }
 
 SheetOperation &DocSheet::operationRef()
@@ -1298,9 +1307,16 @@ void DocSheet::onOpened(deepin_reader::Document::Error error)
             });
         }
 
-        // 恢复侧边栏宽度
-        if (m_restoredFromState && m_operation.sidebarWidth > 0) {
-            m_sidebar->resize(m_operation.sidebarWidth, m_sidebar->height());
+        // 恢复侧边栏宽度（仅当用户主动调整过时才恢复，避免覆盖 QSplitter 默认布局）
+        if (m_restoredFromState && m_operation.sidebarWidthChanged && m_operation.sidebarWidth > 0) {
+            QTimer::singleShot(kRestoreCatalogDelayMs, this, [this]() {
+                if (this->width() > m_operation.sidebarWidth + this->handleWidth()) {
+                    QList<int> sizes;
+                    sizes << m_operation.sidebarWidth;
+                    sizes << this->width() - m_operation.sidebarWidth - this->handleWidth();
+                    this->setSizes(sizes);
+                }
+            });
         }
 
         // 启动定时自动保存
@@ -1629,8 +1645,9 @@ void DocSheet::setAlive(bool alive)
             m_operation.scrollPosition = m_browser->getScrollPosition();
         }
 
-        // 保存目录树展开状态
-        if (m_sidebar) {
+        // 保存侧边栏宽度和目录树展开状态
+        if (m_sidebar && m_sidebar->isVisible()) {
+            m_operation.sidebarWidth = m_sidebar->width();
             m_operation.expandedSections = m_sidebar->getExpandedSections();
         }
 
@@ -1727,6 +1744,56 @@ void DocSheet::onExtractPassword(const QString &password)
     m_password = password;
 
     m_renderer->openFileAsync(m_password);
+}
+
+void DocSheet::saveCurrentViewState()
+{
+    qCDebug(appLog) << "saveCurrentViewState for:" << m_filePath;
+    // 保存滚动位置
+    if (m_browser) {
+        m_operation.scrollPosition = m_browser->getScrollPosition();
+    }
+    // 保存侧边栏宽度和展开状态
+    if (m_sidebar && m_sidebar->isVisible()) {
+        m_operation.sidebarWidth = m_sidebar->width();
+        m_operation.expandedSections = m_sidebar->getExpandedSections();
+    }
+}
+
+void DocSheet::restoreSavedViewState()
+{
+    qCDebug(appLog) << "restoreSavedViewState for:" << m_filePath
+                    << "position:" << m_operation.scrollPosition
+                    << "sidebarWidth:" << m_operation.sidebarWidth;
+    if (!opened())
+        return;
+
+    // 恢复侧边栏宽度（仅当用户主动调整过时才恢复）
+    if (m_sidebar && m_sidebar->isVisible() && m_operation.sidebarWidthChanged && m_operation.sidebarWidth > 0) {
+        QTimer::singleShot(kRestoreCatalogDelayMs, this, [this]() {
+            if (this->width() > m_operation.sidebarWidth + this->handleWidth()) {
+                QList<int> sizes;
+                sizes << m_operation.sidebarWidth;
+                sizes << this->width() - m_operation.sidebarWidth - this->handleWidth();
+                this->setSizes(sizes);
+            }
+        });
+    }
+
+    // 恢复滚动位置
+    if (m_browser && m_operation.scrollPosition > 0.0f) {
+        QTimer::singleShot(kRestoreScrollDelayMs, this, [this]() {
+            m_browser->restoreScrollPosition(m_operation.scrollPosition);
+        });
+    }
+}
+
+float DocSheet::currentScrollPosition() const
+{
+    if (m_browser) {
+        return m_browser->getScrollPosition();
+    }
+    return 0.0f;
 }
 
 SheetRenderer *DocSheet::renderer()
@@ -1918,8 +1985,9 @@ void DocSheet::onAutoSave()
         m_operation.scrollPosition = m_browser->getScrollPosition();
     }
 
-    // 更新目录树展开状态
-    if (m_sidebar) {
+    // 更新侧边栏宽度和目录树展开状态
+    if (m_sidebar && m_sidebar->isVisible()) {
+        m_operation.sidebarWidth = m_sidebar->width();
         m_operation.expandedSections = m_sidebar->getExpandedSections();
     }
 

--- a/reader/uiframe/DocSheet.h
+++ b/reader/uiframe/DocSheet.h
@@ -20,6 +20,10 @@ class SlideWidget;
 class EncryptionPage;
 class QPropertyAnimation;
 class QPrinter;
+
+constexpr int kRestoreScrollDelayMs = 100;
+constexpr int kRestoreCatalogDelayMs = 150;
+
 class PageSearchThread;
 class QTimer;
 struct SheetOperation {
@@ -33,6 +37,8 @@ struct SheetOperation {
     int  currentPage            = 1;
     // 侧边栏宽度
     int  sidebarWidth           = 200;
+    // 标记用户是否主动调整过侧边栏宽度
+    bool sidebarWidthChanged    = false;
     // 滚动位置（纵向偏移比例 0.0~1.0）
     float scrollPosition        = 0.0f;
     // 目录树展开节点标题路径列表（如 ["1.概述", "1.概述/1.1 背景"]）
@@ -443,7 +449,7 @@ public:
 
     /**
      * @brief setSidebarWidth
-     * 设置侧边栏宽度（封装对 m_operation 的访问）
+     * 设置侧边栏宽度并标记为用户主动调整
      * @param width 宽度
      */
     void setSidebarWidth(int width);
@@ -627,6 +633,23 @@ public:
      * @return
      */
     QSizeF pageSizeByIndex(int index);
+
+    /**
+     * @brief 保存当前阅读状态到操作记录中
+     * 包括滚动位置、侧边栏宽度和展开状态，用于标签页切换时保存阅读位置
+     */
+    void saveCurrentViewState();
+
+    /**
+     * @brief 恢复已保存的阅读状态
+     * 包括滚动位置和侧边栏宽度，用于标签页切换回来时恢复阅读位置
+     */
+    void restoreSavedViewState();
+
+    /**
+     * @brief 获取当前滚动位置（0.0~1.0）
+     */
+    float currentScrollPosition() const;
 
     /**
      * @brief renderer


### PR DESCRIPTION
and tab group on startup

Save and restore scroll position and sidebar width on tab switch, persist sidebarWidthChanged flag to distinguish user-adjusted width, and restore last session tab group on app launch.

保存并恢复标签页切换时的滚动位置和侧边栏宽度，新增
sidebarWidthChanged标记区分用户主动调整与默认值，启动时
恢复上次会话的标签页组。

Log: 恢复阅读状态（滚动位置、侧边栏宽度、标签页组）
PMS: TASK-394181
Influence: 用户体验改善——关闭后再打开可恢复上次的标签页和阅读位置，标签页切换时滚动位置不丢失。

## Summary by Sourcery

Restore document reading state and the previous tab group across tab switches and application restarts.

New Features:
- Restore the last session’s tab group on application startup while incorporating newly specified files.
- Preserve and restore document reading state, including scroll position and user-adjusted sidebar width, when switching tabs or reopening the application.

Enhancements:
- Persist whether the sidebar width was explicitly changed by the user so default layouts are not unnecessarily overridden.
- Save active document state and tab groups before closing sheets to retain the latest reading context.

Chores:
- Add database migration and persistence support for the sidebar width change marker.