### PR TITLE
fix: restore tip widget per-sheet state and multi-tab sync (#394181)

### DIFF
--- a/reader/uiframe/Central.cpp
+++ b/reader/uiframe/Central.cpp
@@ -46,8 +46,11 @@ Central::Central(QWidget *parent)
     connect(m_restoreTipWidget, &RestoreTipWidget::sigJumpToFirstPage, this, [this]() {
         if (m_docPage) {
             DocSheet *sheet = m_docPage->getCurSheet();
-            if (sheet)
+            if (sheet) {
+                sheet->dismissRestoreTip();
                 sheet->jumpToFirstPage();
+                m_restoreTipWidget->hide();
+            }
         }
     });
 
@@ -125,10 +128,22 @@ CentralDocPage *Central::docPage()
         connect(m_docPage, SIGNAL(sigNeedOpenFilesExec()), SLOT(onOpenFilesExec()));
         connect(m_docPage, SIGNAL(sigNeedActivateWindow()), this, SLOT(onNeedActivateWindow()));
 
-        // 监听恢复阅读位置提示信号
-        connect(m_docPage, &CentralDocPage::sigShowRestoreTip, this, [this]() {
-            if (m_restoreTipWidget)
+        // 监听恢复阅读位置提示信号（仅当发出者为当前 sheet 时显示）
+        connect(m_docPage, &CentralDocPage::sigShowRestoreTip, this, [this](DocSheet *sheet) {
+            if (!m_restoreTipWidget || !m_docPage)
+                return;
+            if (sheet && sheet == m_docPage->getCurSheet() && sheet->needsRestoreTip())
                 m_restoreTipWidget->showTip();
+        });
+
+        // 标签页切换时，根据当前 sheet 的恢复提示状态同步提示条显隐
+        connect(m_docPage, &CentralDocPage::sigCurSheetChanged, this, [this](DocSheet *sheet) {
+            if (!m_restoreTipWidget || !m_docPage)
+                return;
+            if (sheet && sheet->needsRestoreTip())
+                m_restoreTipWidget->showTip();
+            else
+                m_restoreTipWidget->hide();
         });
     }
     // qCDebug(appLog) << "Getting doc page end";
@@ -251,6 +266,9 @@ void Central::onSheetCountChanged(int count)
         m_layout->setCurrentIndex(0);
         m_navPage->setFocus();
         m_widget->setControlEnabled(false);
+        // 所有标签页关闭时隐藏恢复提示条
+        if (m_restoreTipWidget)
+            m_restoreTipWidget->hide();
     }
 }
 

--- a/reader/uiframe/CentralDocPage.cpp
+++ b/reader/uiframe/CentralDocPage.cpp
@@ -682,8 +682,10 @@ void CentralDocPage::handleShortcut(const QString &s)
     if (s == Dr::key_ctrl_home) {
         qCInfo(appLog) << "s == Dr::key_ctrl_home";
         auto sheet = getCurSheet();
-        if (sheet)
+        if (sheet) {
+            sheet->dismissRestoreTip();
             sheet->jumpToFirstPage();
+        }
     }
     if (s == Dr::key_ctrl_end) {
         qCInfo(appLog) << "s == Dr::key_ctrl_end";

--- a/reader/uiframe/CentralDocPage.h
+++ b/reader/uiframe/CentralDocPage.h
@@ -285,8 +285,9 @@ signals:
     /**
      * @brief sigShowRestoreTip
      * 请求显示恢复阅读位置提示条
+     * @param sheet 发出请求的文档
      */
-    void sigShowRestoreTip();
+    void sigShowRestoreTip(DocSheet *sheet);
 
     /**
      * @brief sigNeedClose

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -296,6 +296,12 @@ void DocSheet::jumpToFirstPage()
     m_browser->setCurrentPage(1);
 }
 
+void DocSheet::dismissRestoreTip()
+{
+    qCDebug(appLog) << "dismissRestoreTip";
+    m_needsRestoreTip = false;
+}
+
 void DocSheet::jumpToLastPage()
 {
     qCDebug(appLog) << "jumpToLastPage";
@@ -1293,7 +1299,8 @@ void DocSheet::onOpened(deepin_reader::Document::Error error)
             QTimer::singleShot(kRestoreScrollDelayMs, this, [this]() {
                 m_browser->restoreScrollPosition(m_operation.scrollPosition);
                 // 显示恢复提示条
-                emit sigShowRestoreTip();
+                m_needsRestoreTip = true;
+                emit sigShowRestoreTip(this);
                 emit sigStateRestored(this);
             });
         }
@@ -1478,6 +1485,7 @@ void DocSheet::onBrowserPageChanged(int page)
 void DocSheet::onBrowserPageFirst()
 {
     qCDebug(appLog) << "onBrowserPageFirst";
+    dismissRestoreTip();
     jumpToFirstPage();
 }
 
@@ -1996,4 +2004,9 @@ void DocSheet::onAutoSave()
         m_cachedContentHash = Database::computeContentHash(m_filePath);
     }
     Database::instance()->saveOperation(this, m_cachedContentHash);
+}
+
+bool DocSheet::needsRestoreTip() const
+{
+    return m_needsRestoreTip;
 }

--- a/reader/uiframe/DocSheet.h
+++ b/reader/uiframe/DocSheet.h
@@ -641,6 +641,18 @@ public:
     void saveCurrentViewState();
 
     /**
+     * @brief needsRestoreTip 该 sheet 是否仍需要显示恢复阅读位置提示条
+     */
+    bool needsRestoreTip() const;
+
+    /**
+     * @brief dismissRestoreTip 清除恢复提示标记并隐藏提示条
+     * 在用户主动跳转首页（按钮/快捷键/翻页控件）时由调用方显式调用，
+     * 不放在 jumpToFirstPage() 内以避免隐式副作用扩散。
+     */
+    void dismissRestoreTip();
+
+    /**
      * @brief 恢复已保存的阅读状态
      * 包括滚动位置和侧边栏宽度，用于标签页切换回来时恢复阅读位置
      */
@@ -808,8 +820,9 @@ signals:
     /**
      * @brief sigShowRestoreTip
      * 请求显示恢复阅读位置提示条
+     * @param sheet 发出请求的文档，Central 据此判断是否为当前活跃标签
      */
-    void sigShowRestoreTip();
+    void sigShowRestoreTip(DocSheet *sheet);
 
 private slots:
     /**
@@ -913,9 +926,11 @@ private:
 
     // 定时自动保存
     QTimer *m_autoSaveTimer = nullptr;
-    // 恢复阅读位置提示条
     // 标记是否从保存状态恢复
     bool m_restoredFromState = false;
+    // 标记该 sheet 是否仍需要显示恢复阅读位置提示条
+    // 用户点击"跳转到首页"后置为 false，切换 tab 时据此决定是否显示提示条
+    bool m_needsRestoreTip = false;
     // 缓存的内容哈希，避免自动保存时反复读盘计算
     QString m_cachedContentHash;
 


### PR DESCRIPTION
Each DocSheet now independently tracks restore tip visibility via m_needsRestoreTip. sigShowRestoreTip carries the sender sheet so Central only shows the tip for the active tab. Tab switching syncs tip visibility. dismissRestoreTip() separates side-effect from jumpToFirstPage() to avoid implicit coupling.

修复恢复阅读位置提示条在多标签页场景下的联动问题，
每个sheet独立管理提示状态，标签切换时同步显隐，
用户跳转首页/Ctrl+Home/翻页控件时显式清除提示标记。

Log: 修复多标签页恢复提示条联动问题
PMS: BUG-394181
Influence: 恢复阅读位置提示条现可在多标签页间正确联动，切tab后仍能看到对应文档的跳转提示

## Summary by Sourcery

Fix restore-reading-position tip state and visibility across multiple document tabs.

Bug Fixes:
- Restore reading-position tips independently per document tab and keep their visibility synchronized when switching tabs.
- Clear the restore tip state when users explicitly navigate to the first page or dismiss the tip.

Enhancements:
- Restrict restore-tip display requests to the currently active document sheet and hide the tip when all tabs are closed.