### PR TITLE
feat: 补全 AT-SPI 无障碍名称

### DIFF
--- a/reader/MainWindow.cpp
+++ b/reader/MainWindow.cpp
@@ -630,6 +630,7 @@ void MainWindow::initBase()
     this->setProperty("windowClosed", false);
 
     m_menu = new TitleMenu(this);
+    m_menu->setObjectName("Menu");
 
     m_menu->setAccessibleName("Menu_Title");
 

--- a/reader/browser/BrowserMenu.cpp
+++ b/reader/browser/BrowserMenu.cpp
@@ -66,6 +66,7 @@ void BrowserMenu::initActions(DocSheet *sheet, int index, SheetMenuType_e type, 
             }
 
             m_pColorWidgetAction = new ColorWidgetAction(this);
+            m_pColorWidgetAction->setObjectName("PColorWidgetAction");
             connect(m_pColorWidgetAction, SIGNAL(sigBtnGroupClicked()), this, SLOT(onSetHighLight()));
             this->addAction(m_pColorWidgetAction);
         }

--- a/reader/uiframe/TitleMenu.cpp
+++ b/reader/uiframe/TitleMenu.cpp
@@ -35,9 +35,11 @@ TitleMenu::TitleMenu(DWidget *parent)
 
     // 阅读模式（护眼模式）菜单项
     m_eyeProtectionAction = new EyeProtectionAction(this);
+    m_eyeProtectionAction->setObjectName("EyeProtectionAction");
     this->addAction(m_eyeProtectionAction);
 
     m_handleMenu = new HandleMenu(this);
+    m_handleMenu->setObjectName("HandleMenu");
     m_handleMenu->setDisabled(true);
     m_handleMenu->setTitle(tr("Tools"));
     m_handleMenu->setAccessibleName("Menu_Hand");

--- a/reader/widgets/EncryptionPage.cpp
+++ b/reader/widgets/EncryptionPage.cpp
@@ -41,6 +41,8 @@ void EncryptionPage::InitUI()
     stringinfolabel->setText(tr("Encrypted file, please enter the password"));
 
     m_password = new DPasswordEdit(this);
+    m_password->setObjectName("Password");
+    m_password->setAccessibleName("Password");
     m_password->setFixedSize(360, 36);
     QLineEdit *edit = m_password->lineEdit();
     edit->setObjectName("passwdEdit");

--- a/reader/widgets/RestoreTipWidget.cpp
+++ b/reader/widgets/RestoreTipWidget.cpp
@@ -53,6 +53,8 @@ void RestoreTipWidget::initUI()
     layout->addStretch(1);
 
     m_jumpBtn = new DPushButton(tr("Jump to first page"), this);
+    m_jumpBtn->setObjectName("JumpBtn");
+    m_jumpBtn->setAccessibleName("JumpBtn");
     m_jumpBtn->setFixedHeight(28);
     m_jumpBtn->setFocusPolicy(Qt::NoFocus);
     DFontSizeManager::instance()->bind(m_jumpBtn, DFontSizeManager::T8);
@@ -65,6 +67,8 @@ void RestoreTipWidget::initUI()
 
     DDciIcon closeIcon(QStringLiteral(":/icons/deepin/builtin/icons/dr_close_16px.dci"));
     m_closeBtn = new DIconButton(closeIcon, this);
+    m_closeBtn->setObjectName("CloseBtn");
+    m_closeBtn->setAccessibleName("CloseBtn");
     m_closeBtn->setFixedSize(28, 28);
     m_closeBtn->setIconSize(QSize(16, 16));
     m_closeBtn->setFlat(true);

--- a/reader/widgets/ScaleMenu.cpp
+++ b/reader/widgets/ScaleMenu.cpp
@@ -27,6 +27,11 @@ void ScaleMenu::readCurDocParam(DocSheet *docSheet)
     m_pFitWorHAction    = createAction(tr("Fit Page"), SLOT(onFitPage()), true);
     m_pFiteHAction      = createAction(tr("Fit Height"), SLOT(onFiteH()), true);
     m_pFiteWAction      = createAction(tr("Fit Width"), SLOT(onFiteW()), true);
+    m_pTwoPageAction->setObjectName("PTwoPageAction");
+    m_pFitDefaultAction->setObjectName("PFitDefaultAction");
+    m_pFitWorHAction->setObjectName("PFitWorHaction");
+    m_pFiteHAction->setObjectName("PFiteHaction");
+    m_pFiteWAction->setObjectName("PFiteWaction");
 
     addSeparator();
     const QList<qreal> &scaleFactorlst = m_sheet->scaleFactorList();

--- a/reader/widgets/SlidePlayWidget.cpp
+++ b/reader/widgets/SlidePlayWidget.cpp
@@ -45,6 +45,12 @@ void SlidePlayWidget::initControl()
     m_nextBtn = createBtn(QString("next_normal"));
     DIconButton *pbtnexit = createBtn(QString("exit_normal"));
     m_playBtn = pbtnplay;
+    m_preBtn->setObjectName("PreBtn");
+    m_preBtn->setAccessibleName("PreBtn");
+    m_nextBtn->setObjectName("NextBtn");
+    m_nextBtn->setAccessibleName("NextBtn");
+    m_playBtn->setObjectName("PlayBtn");
+    m_playBtn->setAccessibleName("PlayBtn");
 
     playout->addWidget(m_preBtn);
     playout->addWidget(pbtnplay);

--- a/reader/widgets/TextEditWidget.cpp
+++ b/reader/widgets/TextEditWidget.cpp
@@ -206,6 +206,8 @@ void TextEditWidget::initWidget()
     pHLayoutContant->setContentsMargins(20, 20, 6, 20);
 
     m_pTextEdit = new TransparentTextEdit(this);
+    m_pTextEdit->setObjectName("PTextEdit");
+    m_pTextEdit->setAccessibleName("PTextEdit");
     connect(m_pTextEdit, SIGNAL(sigNeedShowTips(const QString &, int)), this, SIGNAL(sigNeedShowTips(const QString &, int)));
 
     pHLayoutContant->addWidget(m_pTextEdit);


### PR DESCRIPTION
## 概述

为缺失无障碍名称的交互控件添加 setObjectName/setAccessibleName 调用，提升 AT-SPI 覆盖率。

## 覆盖率对比

| 指标 | 补全前 | 补全后 |
| --- | --- | --- |
| 总控件数 | 44 | 44 |
| 已命名 | 20 | 32 |
| 缺失 | 24 | 12 |
| 覆盖率 | 45.5% | 72.7% |

## 修改文件 (8 files, +23 lines)

- reader/MainWindow.cpp
- reader/browser/BrowserMenu.cpp
- reader/uiframe/TitleMenu.cpp
- reader/widgets/EncryptionPage.cpp
- reader/widgets/RestoreTipWidget.cpp
- reader/widgets/ScaleMenu.cpp
- reader/widgets/SlidePlayWidget.cpp
- reader/widgets/TextEditWidget.cpp

## 验证

- 本地编译通过（cmake + make 100%）
- 补全后重新扫描验证覆盖率提升

## Summary by Sourcery

Complete AT-SPI naming for interactive reader controls to improve accessibility coverage.

New Features:
- Add object and accessibility names to previously unnamed menus, actions, buttons, password fields, and text-edit controls to improve AT-SPI discoverability.

Enhancements:
- Improve accessibility-name coverage across the reader interface.