### PR TITLE
fix(sidebar): invert thumbnail luminance in dark theme

### DIFF
--- a/reader/sidebar/SideBarImageListview.cpp
+++ b/reader/sidebar/SideBarImageListview.cpp
@@ -11,6 +11,8 @@
 #include "ThumbnailWidget.h"
 #include "ddlog.h"
 
+#include <DGuiApplicationHelper>
+
 #include <QScroller>
 #include <QScrollBar>
 #include <QSet>
@@ -43,6 +45,10 @@ SideBarImageListView::SideBarImageListView(DocSheet *sheet, QWidget *parent)
     connect(verticalScrollBar(), &QScrollBar::sliderPressed, this, &SideBarImageListView::onRemoveThumbnailListSlideGesture);
     connect(verticalScrollBar(), &QScrollBar::sliderReleased, this, &SideBarImageListView::onSetThumbnailListSlideGesture);
     qCDebug(appLog) << "Connected scrollbar signals";
+
+    // 主题切换时刷新可见缩略图，使 ThumbnailDelegate 按新主题反色重绘
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+            this, [this]() { this->viewport()->update(); });
 }
 
 

--- a/reader/sidebar/ThumbnailDelegate.cpp
+++ b/reader/sidebar/ThumbnailDelegate.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,6 +17,7 @@
 #include <QAbstractItemView>
 #include <QPainterPath>
 #include <QTransform>
+#include <QImage>
 ThumbnailDelegate::ThumbnailDelegate(QAbstractItemView *parent)
     : DStyledItemDelegate(parent)
 {
@@ -62,7 +63,42 @@ void ThumbnailDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opt
             QPainterPath clipPath;
             clipPath.addRoundedRect(rect, borderRadius, borderRadius);
             painter->setClipPath(clipPath);
-            painter->drawPixmap(rect.x(), rect.y(), rect.width(), rect.height(), pixmap);
+            // 深色系统主题下，缩略图卡片需与侧边栏深色背景协调：将文档原始白底黑字
+            // 的缩略图反色为黑底白字；浅色主题保持原样。反色仅在绘制时进行，
+            // 不修改 DocSheet 中缓存的真实缩略图(始终为白底)，避免主题切换时双重反色。
+            // 采用与 BrowserPage::applyNightMode 相同的 HSL 亮度反转算法：
+            // 仅反转 Lightness 通道，保留 Hue/Saturation，避免图片色相偏移 180°。
+            //   白底黑字 → 黑底白字（文字/背景正确反色）
+            //   彩色图片/链接 → 仅变暗，色相保持
+            if (DTK_NAMESPACE::Gui::DGuiApplicationHelper::instance()->themeType() == DTK_NAMESPACE::Gui::DGuiApplicationHelper::DarkType) {
+                QImage img = pixmap.toImage();
+                if (!img.isNull()) {
+                    if (img.format() != QImage::Format_ARGB32)
+                        img = img.convertToFormat(QImage::Format_ARGB32);
+                    const int w = img.width();
+                    const int h = img.height();
+                    for (int y = 0; y < h; ++y) {
+                        QRgb *line = reinterpret_cast<QRgb *>(img.scanLine(y));
+                        for (int x = 0; x < w; ++x) {
+                            const QRgb px = line[x];
+                            const int alpha = qAlpha(px);
+                            QColor c = QColor::fromRgb(qRed(px), qGreen(px), qBlue(px));
+                            int hue, sat, light, dummy;
+                            c.getHsl(&hue, &sat, &light, &dummy);
+                            light = 255 - light;
+                            c.setHsl(hue, sat, light);
+                            line[x] = qRgba(c.red(), c.green(), c.blue(), alpha);
+                        }
+                    }
+                    QPixmap invertedPixmap = QPixmap::fromImage(img);
+                    invertedPixmap.setDevicePixelRatio(pixmap.devicePixelRatio());
+                    painter->drawPixmap(rect.x(), rect.y(), rect.width(), rect.height(), invertedPixmap);
+                } else {
+                    painter->drawPixmap(rect.x(), rect.y(), rect.width(), rect.height(), pixmap);
+                }
+            } else {
+                painter->drawPixmap(rect.x(), rect.y(), rect.width(), rect.height(), pixmap);
+            }
             painter->restore();
         }
 


### PR DESCRIPTION
Use HSL lightness inversion (same as BrowserPage::applyNightMode) to render thumbnails with dark background and light text under dark system theme; light theme unchanged. Only Lightness is inverted, Hue/Saturation preserved so colored images stay natural.

深色系统主题下缩略图卡片采用HSL亮度反转变为黑底白字，浅色主题不变；
色相/饱和度保留，彩色图片不偏色。

Log: 深色主题缩略图HSL亮度反色
PMS: BUG-390571

Influence: 深色系统主题下左侧缩略图卡片由白底黑字变为黑底白字，与侧边栏深色背景协调；浅色主题无影响。

## Summary by Sourcery

Align sidebar thumbnail rendering with dark theme appearance while leaving light-theme thumbnails unchanged.

Bug Fixes:
- Render sidebar thumbnails with inverted HSL lightness in dark system themes so white document backgrounds and dark text become dark backgrounds and light text while preserving image hues and saturation.
- Refresh visible thumbnails when the system theme changes so their appearance updates immediately.