### PR TITLE
docs(i18n): rename reading mode to eye protection mode in translations

### DIFF
--- a/translations/deepin-reader.ts
+++ b/translations/deepin-reader.ts
@@ -389,7 +389,7 @@
     <name>EyeProtectionAction</name>
     <message>
         <location filename="../reader/eyeprotection/EyeProtectionAction.cpp" line="52"/>
-        <source>Reading mode</source>
+        <source>Eye protection mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-reader_bo.ts
+++ b/translations/deepin-reader_bo.ts
@@ -389,8 +389,8 @@
     <name>EyeProtectionAction</name>
     <message>
         <location filename="../reader/eyeprotection/EyeProtectionAction.cpp" line="52"/>
-        <source>Reading mode</source>
-        <translation>ལྟ་ཀློག་རྣམ་པ།</translation>
+        <source>Eye protection mode</source>
+        <translation>མིག་སྲུང་བྱེད་སྟངས།</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-reader_ug.ts
+++ b/translations/deepin-reader_ug.ts
@@ -389,8 +389,8 @@
     <name>EyeProtectionAction</name>
     <message>
         <location filename="../reader/eyeprotection/EyeProtectionAction.cpp" line="52"/>
-        <source>Reading mode</source>
-        <translation>ئوقۇش ھالىتى</translation>
+        <source>Eye protection mode</source>
+        <translation>كۆز قوغداش ھالىتى</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-reader_zh_CN.ts
+++ b/translations/deepin-reader_zh_CN.ts
@@ -388,8 +388,8 @@
     <name>EyeProtectionAction</name>
     <message>
         <location filename="../reader/eyeprotection/EyeProtectionAction.cpp" line="52" />
-        <source>Reading mode</source>
-        <translation>阅读模式</translation>
+        <source>Eye protection mode</source>
+        <translation>护眼模式</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-reader_zh_HK.ts
+++ b/translations/deepin-reader_zh_HK.ts
@@ -389,8 +389,8 @@
     <name>EyeProtectionAction</name>
     <message>
         <location filename="../reader/eyeprotection/EyeProtectionAction.cpp" line="52"/>
-        <source>Reading mode</source>
-        <translation>閱讀模式</translation>
+        <source>Eye protection mode</source>
+        <translation>護眼模式</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-reader_zh_TW.ts
+++ b/translations/deepin-reader_zh_TW.ts
@@ -389,8 +389,8 @@
     <name>EyeProtectionAction</name>
     <message>
         <location filename="../reader/eyeprotection/EyeProtectionAction.cpp" line="52"/>
-        <source>Reading mode</source>
-        <translation>閱讀模式</translation>
+        <source>Eye protection mode</source>
+        <translation>護眼模式</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Update the eye protection menu title source string from "Reading mode" to "Eye protection mode" and refresh translations for bo, ug, zh_CN, zh_HK and zh_TW.

将护眼菜单标题源串由"Reading mode"改为"Eye protection mode"，同步更新藏语、维吾尔语、简体中文、繁体中文(港/台)译本为"护眼模式"。

Log: 统一护眼模式菜单标题文案及多语言译本
Influence: 仅影响护眼模式菜单项的显示文案，无功能逻辑变更。

## Summary by Sourcery

Enhancements:
- Rename the eye protection menu source string from “Reading mode” to “Eye protection mode” and update the Tibetan, Uyghur, Simplified Chinese, and Traditional Chinese translations accordingly.