### PR TITLE
feat(eyeprotection): smart HSL luminance inversion for night mode

### DIFF
--- a/reader/browser/BrowserPage.cpp
+++ b/reader/browser/BrowserPage.cpp
@@ -151,29 +151,33 @@ void BrowserPage::paint(QPainter *painter, const QStyleOptionGraphicsItem *optio
         renderViewPort();
     }
 
-    painter->drawPixmap(0, 0, m_renderPixmap);  //m_renderPixmap的大小存在系统缩放，可能不等于option->rect()，需要按坐标绘制
-
-    // 护眼模式背景色叠加
     EyeProtectionManager *epMgr = EyeProtectionManager::instance();
-    if (epMgr->mode() != EyeProtectionManager::Off) {
-        QColor pageBg = epMgr->pageBackgroundColor();
 
-        if (epMgr->mode() == EyeProtectionManager::Night) {
-            // 夜间模式：先完整反色（白底黑字 → 黑底白字）
-            // Exclusion(src=白) 结果 = src + dest - 2*src*dest/255
-            //   白(255) → 0(黑)，黑(0) → 255(白)
-            painter->setCompositionMode(QPainter::CompositionMode_Exclusion);
-            painter->fillRect(boundingRect(), QColor(255, 255, 255, 255));
-            painter->setCompositionMode(QPainter::CompositionMode_SourceOver);
-            // 再叠加深色半透明层降低整体亮度，保持文字清晰可读
-            QColor dark = pageBg;
-            dark.setAlpha(80);
-            painter->fillRect(boundingRect(), dark);
-        } else {
+    if (epMgr->mode() == EyeProtectionManager::Night) {
+        // 夜间模式：智能反色（HSL 亮度反转）
+        // 仅反转 Lightness 通道，保留 Hue/Saturation，避免图片/链接色相偏移 180°
+        //   白底黑字 → 黑底白字（文字/背景正确反色）
+        //   彩色图片/链接 → 仅变暗，色相保持
+        if (m_nightDirty || m_nightPixmap.isNull()) {
+            m_nightPixmap = applyNightMode(m_renderPixmap);
+            m_nightPixmap.setDevicePixelRatio(dApp->devicePixelRatio());
+            m_nightDirty = false;
+        }
+        painter->drawPixmap(0, 0, m_nightPixmap);
+        // 叠加轻微深色半透明层降低整体亮度，保持文字清晰可读
+        QColor dark = epMgr->pageBackgroundColor();
+        dark.setAlpha(60);
+        painter->fillRect(boundingRect(), dark);
+    } else {
+        // 非夜间模式：绘制原图，并按需叠加护眼染色
+        painter->drawPixmap(0, 0, m_renderPixmap);  //m_renderPixmap的大小存在系统缩放，可能不等于option->rect()，需要按坐标绘制
+
+        if (epMgr->mode() != EyeProtectionManager::Off) {
+            QColor pageBg = epMgr->pageBackgroundColor();
             // 经典/绿色护眼：正片叠底(Multiply)染色
             // result = src * dest / 255
             //   白色背景(255)被染为护眼色，黑色文字(0)保持深色不变
-            //   避免使用 SourceAtop 导致黑色文字被覆盖为叠加色
+            //   Multiply 不改变色相，图片/链接仅被染色，色相保持
             painter->setCompositionMode(QPainter::CompositionMode_Multiply);
             painter->fillRect(boundingRect(), pageBg);
             painter->setCompositionMode(QPainter::CompositionMode_SourceOver);
@@ -264,6 +268,7 @@ void BrowserPage::render(const double &scaleFactor, const Dr::Rotation &rotation
                                              static_cast<int>(boundingRect().height() * dApp->devicePixelRatio()));
             m_renderPixmap.setDevicePixelRatio(dApp->devicePixelRatio());
         }
+        m_nightDirty = true;  // m_renderPixmap 已更新，夜间模式反色缓存失效
 
         ++m_pixmapId;
 
@@ -412,6 +417,8 @@ void BrowserPage::handleRenderFinished(const int &pixmapId, const QPixmap &pixma
     m_renderPixmap = m_pixmap;
 
     m_renderPixmap.setDevicePixelRatio(dApp->devicePixelRatio());
+
+    m_nightDirty = true;  // 渲染结果已更新，夜间模式反色缓存失效
 
     update();
     // qCDebug(appLog) << "BrowserPage::handleRenderFinished() - Handle render finished completed";
@@ -609,6 +616,8 @@ void BrowserPage::clearPixmap()
     m_pixmap = QPixmap();
 
     m_renderPixmap = m_pixmap;
+
+    m_nightDirty = true;  // pixmap 已清空，夜间模式反色缓存失效
 
     ++m_pixmapId;
 
@@ -1269,4 +1278,43 @@ bool BrowserPage::isBigDoc()
     bool isBig = supportedType && boundingRect().width() > 1000 && boundingRect().height() > 1000;
     qCDebug(appLog) << "Checking if document is big:" << isBig;
     return isBig;
+}
+
+QPixmap BrowserPage::applyNightMode(const QPixmap &src)
+{
+    if (src.isNull())
+        return src;
+
+    QImage img = src.toImage();
+    if (img.isNull())
+        return src;
+
+    // 统一为 ARGB32 便于逐行扫描
+    if (img.format() != QImage::Format_ARGB32 &&
+        img.format() != QImage::Format_ARGB32_Premultiplied &&
+        img.format() != QImage::Format_RGB32) {
+        img = img.convertToFormat(QImage::Format_ARGB32);
+    }
+
+    const int w = img.width();
+    const int h = img.height();
+
+    for (int y = 0; y < h; ++y) {
+        QRgb *line = reinterpret_cast<QRgb *>(img.scanLine(y));
+        for (int x = 0; x < w; ++x) {
+            QRgb px = line[x];
+            const int alpha = qAlpha(px);
+
+            // HSL 亮度反转：保留色相(H)和饱和度(S)，仅反转亮度(L)
+            // 白(255) → 黑(0)，黑(0) → 白(255)，彩色仅变暗、色相不偏移
+            QColor c = QColor::fromRgb(qRed(px), qGreen(px), qBlue(px));
+            int hue, sat, light, dummy;
+            c.getHsl(&hue, &sat, &light, &dummy);
+            light = 255 - light;
+            c.setHsl(hue, sat, light);
+            line[x] = qRgba(c.red(), c.green(), c.blue(), alpha);
+        }
+    }
+
+    return QPixmap::fromImage(img);
 }

--- a/reader/browser/BrowserPage.h
+++ b/reader/browser/BrowserPage.h
@@ -388,6 +388,16 @@ private:
      */
     bool isBigDoc();
 
+    /**
+     * @brief applyNightMode 夜间模式智能反色
+     * 基于 HSL 亮度反转：仅反转 Lightness 通道，保留 Hue 和 Saturation
+     * 效果：白底黑字 → 黑底白字（文字/背景正确反色）
+     *       彩色图片/链接 → 仅变暗，色相不发生 180° 偏移
+     * @param src 源 pixmap
+     * @return 反色后的 pixmap
+     */
+    QPixmap applyNightMode(const QPixmap &src);
+
 protected:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
 
@@ -435,6 +445,9 @@ private:
     int  m_bookmarkState = 0;                               // 当前书签状态 1为on 2为pressed 3为show
 
     QSizeF m_originSizeF;
+
+    QPixmap m_nightPixmap;      // 夜间模式智能反色缓存
+    bool m_nightDirty = true;   // 缓存失效标记，m_renderPixmap 变化时置 true
 };
 
 #endif // BrowserPage_H

--- a/reader/eyeprotection/EyeProtectionAction.cpp
+++ b/reader/eyeprotection/EyeProtectionAction.cpp
@@ -45,19 +45,19 @@ void EyeProtectionAction::initWidget(DWidget *parent)
     mainLayout->setSpacing(4);
 
     // 第一行：标题
-    DLabel *titleLabel = new DLabel(tr("Reading mode"), pWidget);
+    DLabel *titleLabel = new DLabel(tr("Eye protection mode"), pWidget);
     titleLabel->setForegroundRole(DPalette::TextTitle);
     mainLayout->addWidget(titleLabel);
 
     // 第二行：4个圆形选择控件
     QHBoxLayout *buttonLayout = new QHBoxLayout;
     buttonLayout->setContentsMargins(0, 2, 0, 2);
-    buttonLayout->setSpacing(10);
+    buttonLayout->setSpacing(6);
 
     EyeProtectionManager::Mode curMode = EyeProtectionManager::instance()->mode();
 
     for (int i = 0; i < 4; ++i) {
-        QColor color = EyeProtectionManager::viewportBackgroundColor(
+        QColor color = EyeProtectionManager::pageBackgroundColor(
             static_cast<EyeProtectionManager::Mode>(i));
         auto btn = new RoundColorWidget(color, pWidget);
         btn->setAllClickNotify(true);

--- a/reader/eyeprotection/EyeProtectionManager.cpp
+++ b/reader/eyeprotection/EyeProtectionManager.cpp
@@ -14,11 +14,11 @@ const EyeProtectionManager::ModeColors EyeProtectionManager::s_modeColors[4] = {
     // Off:       页面背景       视口背景       前景色
     { QColor("#FFFFFF"), QColor("#E0E0E0"), QColor("#000000") },
     // Classic:
-    { QColor("#F5F5DC"), QColor("#D6D6B6"), QColor("#333333") },
+    { QColor("#F7F3E8"), QColor("#DEDAD0"), QColor("#333333") },
     // Green:
-    { QColor("#C7EDCC"), QColor("#A8D5AE"), QColor("#333333") },
+    { QColor("#C7EDCC"), QColor("#B3D5B7"), QColor("#333333") },
     // Night:
-    { QColor("#1E1E1E"), QColor("#0A0A0A"), QColor("#E0E0E0") },
+    { QColor("#1E1E1E"), QColor("#252525"), QColor("#E0E0E0") },
 };
 
 EyeProtectionManager *EyeProtectionManager::instance()


### PR DESCRIPTION
Replace Exclusion blend (which shifts hue 180°) with HSL lightness inversion, preserving hue/saturation so images and links keep their original colors. Cache the inverted pixmap per render. Tweak Classic/ Green/Night viewport colors.

夜间模式改用 HSL 亮度反转替代 Exclusion 混合，保留色相/饱和度，
使图片与链接颜色不再发生 180° 偏移；反色结果按渲染缓存。微调
经典/绿色/夜间视口背景色。

Log: 夜间模式智能反色，保留图片链接色相
PMS: BUG-390571
Influence: 夜间模式下文字/背景正确反色，图片与链接色相不再偏移。

## Summary by Sourcery

Improve night mode rendering by preserving content colors while providing readable lightness inversion.

New Features:
- Apply HSL lightness inversion for night mode so text and backgrounds invert while image and link hues remain unchanged.
- Cache the night-mode transformed pixmap and invalidate it when rendered content changes.

Bug Fixes:
- Prevent night mode from shifting image and link colors by 180 degrees.

Enhancements:
- Refine eye-protection mode labels, color selectors, and Classic, Green, and Night palette colors.