### PR TITLE
style(widget): refine RestoreTipWidget appearance

### DIFF
--- a/reader/widgets/RestoreTipWidget.cpp
+++ b/reader/widgets/RestoreTipWidget.cpp
@@ -65,7 +65,7 @@ void RestoreTipWidget::initUI()
 
     DDciIcon closeIcon(QStringLiteral(":/icons/deepin/builtin/icons/dr_close_16px.dci"));
     m_closeBtn = new DIconButton(closeIcon, this);
-    m_closeBtn->setFixedSize(28, 28);
+    m_closeBtn->setFixedSize(16, 16);
     m_closeBtn->setIconSize(QSize(16, 16));
     m_closeBtn->setFlat(true);
     m_closeBtn->setFocusPolicy(Qt::NoFocus);
@@ -86,7 +86,7 @@ void RestoreTipWidget::adjustSize()
     qreal textHeight = fm.height();
     int h = static_cast<int>(qMax(textHeight + 2 * m_tbMargin, static_cast<qreal>(28 + 2 * m_tbMargin)));
     setFixedHeight(h);
-    setMinimumWidth(300);
+    setMinimumWidth(336);
 }
 
 void RestoreTipWidget::showTip()
@@ -103,10 +103,18 @@ void RestoreTipWidget::paintEvent(QPaintEvent *event)
     Q_UNUSED(event)
     QPainter painter(this);
     painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
+
+    // 背景
     painter.setPen(Qt::NoPen);
     painter.setBrush(m_backgroundColor);
-    painter.drawRoundedRect(rect(), 8, 8);
+    painter.drawRoundedRect(rect(), 12, 12);
 
+    QColor borderColor(Qt::black);
+    borderColor.setAlphaF(0.1);
+    QPen borderPen(borderColor, 1);
+    painter.setPen(borderPen);
+    painter.setBrush(Qt::NoBrush);
+    painter.drawRoundedRect(QRectF(rect()).adjusted(0.5, 0.5, -0.5, -0.5), 12, 12);
 }
 
 void RestoreTipWidget::resizeEvent(QResizeEvent *event)


### PR DESCRIPTION
Adjust close button size (28->16), corner radius (8->12), minimum width (300->336) and add a subtle border for the restore tip widget.

调整恢复提示控件的关闭按钮尺寸、圆角、最小宽度并增加细边框。

Log: 优化恢复提示控件外观
PMS: BUG-390571
Influence: 仅影响恢复提示控件的视觉效果，无功能变更。

## Summary by Sourcery

Enhancements:
- Refine the restore tip widget’s visual styling with a smaller close button, wider layout, rounder corners, and a subtle border.