### PR TITLE
feat(widget): add hover border effect to RoundColorWidget

### DIFF
--- a/reader/widgets/RoundColorWidget.cpp
+++ b/reader/widgets/RoundColorWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -47,9 +47,28 @@ void RoundColorWidget::mousePressEvent(QMouseEvent *event)
     }
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+void RoundColorWidget::enterEvent(QEvent *event)
+#else
+void RoundColorWidget::enterEvent(QEnterEvent *event)
+#endif
+{
+    qCDebug(appLog) << "RoundColorWidget enterEvent";
+    m_isHovered = true;
+    update();
+    DWidget::enterEvent(event);
+}
+
+void RoundColorWidget::leaveEvent(QEvent *event)
+{
+    qCDebug(appLog) << "RoundColorWidget leaveEvent";
+    m_isHovered = false;
+    update();
+    DWidget::leaveEvent(event);
+}
+
 void RoundColorWidget::paintEvent(QPaintEvent *event)
 {
-    // qCDebug(appLog) << "RoundColorWidget paintEvent";
     Q_UNUSED(event)
     QPainter painter(this);
     painter.setPen(Qt::NoPen);
@@ -59,12 +78,20 @@ void RoundColorWidget::paintEvent(QPaintEvent *event)
 
     QRect squareRect = rect();
     if (m_isSelected) {
-        // qCDebug(appLog) << "RoundColorWidget paintEvent m_isSelected";
-        //draw select circle
         QColor highlightColor = DGuiApplicationHelper::instance()->applicationPalette().highlight().color();
         QPen pen;
         pen.setBrush(QBrush(highlightColor));
         pen.setWidth(borderWidth);  //pen width
+        painter.setPen(pen);
+        QRect r = squareRect.adjusted(3, 3, -3, -3);
+        painter.drawEllipse(r);
+    } else if (m_isHovered) {
+        bool isDark = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+        QColor hoverColor = isDark ? Qt::white : Qt::black;
+        hoverColor.setAlpha(38);
+        QPen pen;
+        pen.setBrush(QBrush(hoverColor));
+        pen.setWidth(borderWidth);
         painter.setPen(pen);
         QRect r = squareRect.adjusted(3, 3, -3, -3);
         painter.drawEllipse(r);
@@ -84,5 +111,4 @@ void RoundColorWidget::paintEvent(QPaintEvent *event)
         painter.setBrush(Qt::NoBrush);
         painter.drawEllipse(r);
     }
-    // qCDebug(appLog) << "RoundColorWidget paintEvent end";
 }

--- a/reader/widgets/RoundColorWidget.h
+++ b/reader/widgets/RoundColorWidget.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,9 @@
 
 #include <DWidget>
 #include <QMouseEvent>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QEnterEvent>
+#endif
 
 DWIDGET_USE_NAMESPACE
 
@@ -53,6 +56,24 @@ protected:
     void mousePressEvent(QMouseEvent *event);
 
     /**
+     * @brief enterEvent
+     * 鼠标进入事件，触发 hover 灰色边框
+     * @param event
+     */
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    void enterEvent(QEvent *event) override;
+#else
+    void enterEvent(QEnterEvent *event) override;
+#endif
+
+    /**
+     * @brief leaveEvent
+     * 鼠标离开事件，取消 hover 灰色边框
+     * @param event
+     */
+    void leaveEvent(QEvent *event) override;
+
+    /**
      * @brief paintEvent
      * 绘制事件
      * @param event
@@ -61,6 +82,7 @@ protected:
 
 private:
     bool m_isSelected = false;
+    bool m_isHovered = false;
     QColor m_color;
     bool m_allnotify = false;
 };


### PR DESCRIPTION
Add enter/leave event handlers to draw a theme-aware hover border on the round color button (15% black in light, 15% white in dark).

为圆形颜色按钮添加鼠标悬停边框效果，浅色主题用15%黑、深色主题用15%白。

Log: 添加RoundColorWidget悬停边框效果
PMS: TASK-394181
Influence: 颜色选项按钮鼠标悬停时显示边框反馈，提升交互体验，不影响选中态显示。

## Summary by Sourcery

New Features:
- Add theme-aware hover border feedback to round color buttons while preserving the selected-state appearance.