### PR TITLE
fix(sidebar): align catalog scrollbar to far-right edge

### DIFF
--- a/reader/sidebar/CatalogWidget.cpp
+++ b/reader/sidebar/CatalogWidget.cpp
@@ -48,6 +48,7 @@ void CatalogWidget::initWidget()
     titleLayout->addWidget(titleLabel);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
+    mainLayout->setContentsMargins(0, 0, 0, 0);
 
     mainLayout->addLayout(titleLayout);
 


### PR DESCRIPTION
## 概述

修复 CatalogWidget 目录侧边栏垂直滚动条内缩 9px 的问题，使其与侧边栏其余 4 个可滚动组件（缩略图、书签、批注、搜索）统一为 0px 右边距，滚动条贴齐侧边栏右边缘。

## 问题

`CatalogWidget` 的 `mainLayout`（QVBoxLayout）未设置 `contentsMargins`，使用 Qt 默认 9px 四边边距，导致 `CatalogTreeView` 的垂直滚动条距侧边栏右边缘内缩 9px，"floating inside an inset gutter"。

其余 4 个侧边栏组件均显式设置了 `setContentsMargins(0, *, 0, 0)`，唯独 CatalogWidget 遗漏。

## 修改

仅 1 行，在 `reader/sidebar/CatalogWidget.cpp:51` 添加：

```cpp
mainLayout->setContentsMargins(0, 0, 0, 0);
```

## 设计规范依据

依据 DTK/UOS Design 规范 `layout-density.md`：
> Vertical scrollbars should land on the far-right edge of the content area instead of floating inside inset gutters.

`hard-fails.md` 亦将 "vertical scrollbar still floats inside an inset gutter" 列为阻断性缺陷。

## 验证

- 本地编译通过（cmake + make 100%）
- 运行时验证：目录侧边栏滚动条现已贴齐右边缘，与其他组件一致

## 关联

PMS: [BUG-375255](https://pms.uniontech.com/bug-view-375255.html)

## Summary by Sourcery

Bug Fixes:
- Align the catalog sidebar scrollbar with the far-right edge by removing the layout's default outer margins.