### PR TITLE
fix(catalog): 目录页码使用默认文本色

### DIFF
--- a/reader/sidebar/CatalogTreeView.cpp
+++ b/reader/sidebar/CatalogTreeView.cpp
@@ -178,8 +178,6 @@ QList<QStandardItem *> CatalogTreeView::getItemList(const QString &title, const 
     item1->setData(realleft, Qt::UserRole + 2);
     item1->setData(realtop, Qt::UserRole + 3);
     item1->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    QColor color = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette().textTips().color();
-    item1->setForeground(QBrush(color));
 
     qCDebug(appLog) << "CatalogTreeView::getItemList() - Returning item list";
     return QList<QStandardItem *>() << item << item1;


### PR DESCRIPTION
## 问题

侧边栏目录页码在浅色主题下看不清，对比度不足。

## 根因

`CatalogTreeView::getItemList()` 中，页码列（column 1）前景色被设为 `textTips()`：

```cpp
QColor color = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette().textTips().color();
item1->setForeground(QBrush(color));
```

两个问题：

1. **低对比度**：`textTips()` 是半透明颜色（浅色主题下 alpha 0.6 黑色 ≈ `#666666`），语义为提示/占位文本，不应用于页码这类内容信息。页码比标题列（使用默认不透明文本色）更难看清。

2. **不随主题切换**：颜色在 item 创建时缓存为静态 `QBrush`，主题切换后调色板更新但缓存的画笔不刷新，导致页码颜色不响应主题变化。

## 修复

移除 `setForeground()` 调用，页码回退到视图默认调色板文本色——完全不透明、高对比度、绘制时动态解析，随主题切换自动适配。

## 改动

1 个文件，2 行删除，0 行新增。

```diff
  item1->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
- QColor color = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette().textTips().color();
- item1->setForeground(QBrush(color));
  qCDebug(appLog) << "CatalogTreeView::getItemList() - Returning item list";
```

## DTK 规范合规性

- `TextTips` 语义为提示性文本，页码是内容信息，语义误用已纠正
- 移除静态颜色缓存，改为绘制时动态解析调色板，符合主题切换规范
- `#include <DGuiApplicationHelper>` 仍被 `paintEvent` 使用，无未使用 include

## 验证

- 构建成功
- 运行时 `ForegroundRole` 日志确认 col=1 返回 `valid=false`，视图使用默认不透明文本色
- 目录树正确填充 200+ 条目

PMS: [BUG-375491](https://pms.uniontech.com/bug-view-375491.html)
