### PR TITLE
test(at): stabilize deepin-reader AT yaml suites

### DIFF
--- a/tests/at/yaml/主界面 — 无文档打开/主界面 — 无文档打开.suite.yaml
+++ b/tests/at/yaml/主界面 — 无文档打开/主界面 — 无文档打开.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader
   wait: 3.0
 suites:
 - id: suite_main_no_doc_s1

--- a/tests/at/yaml/右键侧栏书签菜单/右键侧栏书签菜单.suite.yaml
+++ b/tests/at/yaml/右键侧栏书签菜单/右键侧栏书签菜单.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_context_menu_bookmark_s1
@@ -24,6 +24,7 @@ suites:
       name: Form_CentralDocPage
     items:
     - 添加书签
+    wait: 5.0
   - action: mouse_click
     selector:
       name: Button_bookmark
@@ -42,6 +43,7 @@ suites:
       name: Form_CentralDocPage
     items:
     - 添加书签
+    wait: 5.0
   - action: mouse_click
     selector:
       name: Button_bookmark

--- a/tests/at/yaml/右键侧栏注释菜单/右键侧栏注释菜单.suite.yaml
+++ b/tests/at/yaml/右键侧栏注释菜单/右键侧栏注释菜单.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_context_menu_note_s1
@@ -24,6 +24,7 @@ suites:
       name: Form_CentralDocPage
     items:
     - 添加注释
+    wait: 5.0
   - action: mouse_click
     selector:
       name: Button_annotation
@@ -54,6 +55,7 @@ suites:
       name: Form_CentralDocPage
     items:
     - 添加注释
+    wait: 5.0
   - action: mouse_click
     selector:
       name: Button_annotation

--- a/tests/at/yaml/右键文档区域菜单/右键文档区域菜单.suite.yaml
+++ b/tests/at/yaml/右键文档区域菜单/右键文档区域菜单.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_context_menu_doc_s1

--- a/tests/at/yaml/右键缩放区域菜单/右键缩放区域菜单.suite.yaml
+++ b/tests/at/yaml/右键缩放区域菜单/右键缩放区域菜单.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_context_menu_scale_s1
@@ -20,35 +20,35 @@ suites:
       name: Form_CentralDocPage
   - action: dtk_context_menu
     selector:
-      name: Form_scaleEdit_P
+      name: Form_LineEdit
       child_index: 1
       popup: click
     items:
     - 双页显示
   - action: dtk_context_menu
     selector:
-      name: Form_scaleEdit_P
+      name: Form_LineEdit
       child_index: 1
       popup: click
     items:
     - 默认大小
   - action: dtk_context_menu
     selector:
-      name: Form_scaleEdit_P
+      name: Form_LineEdit
       child_index: 1
       popup: click
     items:
     - 适合页面
   - action: dtk_context_menu
     selector:
-      name: Form_scaleEdit_P
+      name: Form_LineEdit
       child_index: 1
       popup: click
     items:
     - 适应高度
   - action: dtk_context_menu
     selector:
-      name: Form_scaleEdit_P
+      name: Form_LineEdit
       child_index: 1
       popup: click
     items:

--- a/tests/at/yaml/左侧栏 — 书签视图/左侧栏 — 书签视图.suite.yaml
+++ b/tests/at/yaml/左侧栏 — 书签视图/左侧栏 — 书签视图.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_sidebar_bookmarks_s1
@@ -19,6 +19,7 @@ suites:
     ref: n224
     selector:
       name: Button_ThumbnailToggle
+    wait: 5.0
   - action: mouse_click
     ref: n16
     selector:

--- a/tests/at/yaml/左侧栏 — 按钮切换/左侧栏 — 按钮切换.suite.yaml
+++ b/tests/at/yaml/左侧栏 — 按钮切换/左侧栏 — 按钮切换.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_sidebar_tabs_s1
@@ -19,6 +19,7 @@ suites:
     ref: n224
     selector:
       name: Button_ThumbnailToggle
+    wait: 5.0
   - action: mouse_click
     ref: n14
     selector:

--- a/tests/at/yaml/左侧栏 — 目录视图/左侧栏 — 目录视图.suite.yaml
+++ b/tests/at/yaml/左侧栏 — 目录视图/左侧栏 — 目录视图.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_sidebar_catalog_s1
@@ -19,6 +19,7 @@ suites:
     ref: n224
     selector:
       name: Button_ThumbnailToggle
+    wait: 5.0
   - action: mouse_click
     ref: n15
     selector:

--- a/tests/at/yaml/左侧栏 — 缩略图视图/左侧栏 — 缩略图视图.suite.yaml
+++ b/tests/at/yaml/左侧栏 — 缩略图视图/左侧栏 — 缩略图视图.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_sidebar_thumbnails_s1
@@ -19,6 +19,7 @@ suites:
     ref: n224
     selector:
       name: Button_ThumbnailToggle
+    wait: 5.0
   - action: mouse_click
     ref: n14
     selector:

--- a/tests/at/yaml/标题栏主菜单/标题栏主菜单.suite.yaml
+++ b/tests/at/yaml/标题栏主菜单/标题栏主菜单.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_titlebar_main_menu_s1
@@ -17,17 +17,18 @@ suites:
   steps:
   - action: dtk_main_menu
     items:
+    - 搜索
+  - action: keyboard_press
+    key: escape
+    wait: 1.0
+  - action: dtk_main_menu
+    items:
     - 工具
     - 选择工具
   - action: dtk_main_menu
     items:
     - 工具
     - 手形工具
-  - action: dtk_main_menu
-    items:
-    - 搜索
-  - action: keyboard_press
-    key: escape
   assert_steps:
   - action: assert_element
     selector:

--- a/tests/at/yaml/标题栏主题菜单/标题栏主题菜单.suite.yaml
+++ b/tests/at/yaml/标题栏主题菜单/标题栏主题菜单.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader
   wait: 3.0
 suites:
 - id: suite_theme_menu_v2_s1

--- a/tests/at/yaml/标题栏搜索框/标题栏搜索框.suite.yaml
+++ b/tests/at/yaml/标题栏搜索框/标题栏搜索框.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_titlebar_search_s1

--- a/tests/at/yaml/标题栏缩放输入框/标题栏缩放输入框.suite.yaml
+++ b/tests/at/yaml/标题栏缩放输入框/标题栏缩放输入框.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_titlebar_scale_s1

--- a/tests/at/yaml/顶部标签页栏/顶部标签页栏.suite.yaml
+++ b/tests/at/yaml/顶部标签页栏/顶部标签页栏.suite.yaml
@@ -7,7 +7,7 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-reader ${TEST_FILES_DIR}/normal.pdf
+  command: pkill -9 -x deepin-reader || true; sleep 1; rm -rf ~/.local/share/deepin/deepin-reader ~/.config/deepin/deepin-reader ~/.cache/deepin/deepin-reader; deepin-reader ${TEST_FILES_DIR}/normal.pdf
   wait: 3.0
 suites:
 - id: suite_tab_management_s1


### PR DESCRIPTION
Isolate reader session state and update runtime selectors for AT tests.

隔离阅读器会话状态，并更新运行时变化的AT元素定位。

Log: 稳定deepin-reader AT自动化用例
Influence: 修复会话恢复导致的AT用例状态污染问题，当前本地14/14通过。

## Summary by Sourcery

Stabilize deepin-reader accessibility test suites by isolating reader session state and adapting selectors to the current runtime UI.

Bug Fixes:
- Prevent session restoration from contaminating the state of deepin-reader accessibility test cases.
- Update accessibility test selectors to remain compatible with runtime UI changes.

Tests:
- Stabilize the deepin-reader YAML accessibility test suites across reader, navigation, sidebar, title, and document workflows.