### PR TITLE
test: add unit tests for eye protection, restore tip and view state

### DIFF
--- a/tests/app/ut_database.cpp
+++ b/tests/app/ut_database.cpp
@@ -141,3 +141,50 @@ TEST_F(TestDatabase, UT_Database_saveBookmarks_001)
     EXPECT_TRUE(m_tester->saveBookmarks(strPath, bookmarks));
 }
 
+
+TEST_F(TestDatabase, UT_Database_prepareTabGroup_001)
+{
+    QSqlQuery drop(m_tester->m_database);
+    drop.exec("DROP TABLE IF EXISTS tabgroup");
+    EXPECT_TRUE(m_tester->prepareTabGroup());      // 全新建表
+    EXPECT_FALSE(m_tester->prepareTabGroup());     // 表已存在
+}
+
+TEST_F(TestDatabase, UT_Database_tabGroup_001)
+{
+    QSqlQuery drop(m_tester->m_database);
+    drop.exec("DROP TABLE IF EXISTS tabgroup");
+    ASSERT_TRUE(m_tester->prepareTabGroup());
+
+    EXPECT_TRUE(m_tester->saveTabGroup(0, QStringList() << "/tmp/a.pdf" << "/tmp/b.pdf" << "/tmp/c.pdf", 1));
+
+    int activeIndex = -1;
+    QStringList files = m_tester->readTabGroup(0, activeIndex);
+    EXPECT_EQ(files.size(), 3);
+    EXPECT_EQ(activeIndex, 1);
+    EXPECT_TRUE(files.contains("/tmp/b.pdf"));
+
+    // 覆盖旧记录后仅剩 1 条
+    EXPECT_TRUE(m_tester->saveTabGroup(0, QStringList() << "/tmp/d.pdf", 0));
+    files = m_tester->readTabGroup(0, activeIndex);
+    EXPECT_EQ(files.size(), 1);
+    EXPECT_EQ(activeIndex, 0);
+
+    EXPECT_TRUE(m_tester->clearTabGroup(0));
+    files = m_tester->readTabGroup(0, activeIndex);
+    EXPECT_TRUE(files.isEmpty());
+}
+
+TEST_F(TestDatabase, UT_Database_cleanupOrphanStates_001)
+{
+    // 构造一条指向不存在文件的阅读记录（不在 /media、/mnt、/run/media 下）
+    QString orphanPath = "/tmp/deepin_reader_ut_orphan_cleanup.pdf";
+    QFile::remove(orphanPath);
+    DocSheet orphanSheet(Dr::FileType::PDF, orphanPath, nullptr);
+    EXPECT_TRUE(m_tester->saveOperation(&orphanSheet));
+
+    int cleaned = m_tester->cleanupOrphanStates();
+    EXPECT_GE(cleaned, 1);
+    // 孤儿记录已被清理，再次执行返回 0
+    EXPECT_EQ(m_tester->cleanupOrphanStates(), 0);
+}

--- a/tests/browser/ut_browserpage.cpp
+++ b/tests/browser/ut_browserpage.cpp
@@ -834,3 +834,14 @@ TEST_F(TestBrowserPage, UT_BrowserPage_isBigDoc_001)
     s.set(A_foo, boundingRect_stub2);
     EXPECT_TRUE(m_tester->isBigDoc());
 }
+
+TEST_F(TestBrowserPage, UT_BrowserPage_applyNightMode_001)
+{
+    QPixmap nullPix;
+    EXPECT_TRUE(m_tester->applyNightMode(nullPix).isNull());
+
+    QPixmap src(16, 16);
+    src.fill(Qt::white);
+    QPixmap dst = m_tester->applyNightMode(src);
+    EXPECT_FALSE(dst.isNull());
+}

--- a/tests/browser/ut_sheetbrowser.cpp
+++ b/tests/browser/ut_sheetbrowser.cpp
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "SheetBrowser.h"
+#include "EyeProtectionManager.h"
+#include <QScrollBar>
 #include "BrowserPage.h"
 #include "BrowserWord.h"
 #include "BrowserMenu.h"
@@ -2647,4 +2649,22 @@ TEST_F(TestSheetBrowser, testmousePressEvent_lambda)
     delete sheet;
     qDeleteAll(g_QGraphicsItemList);
     g_QGraphicsItemList.clear();
+}
+
+TEST_F(TestSheetBrowser, UT_SheetBrowser_restoreScrollPosition_001)
+{
+    // 滚动范围未就绪分支
+    m_tester->restoreScrollPosition(0.5f);
+    SUCCEED();
+}
+
+TEST_F(TestSheetBrowser, UT_SheetBrowser_eyeProtectionMode_lambda_001)
+{
+    EyeProtectionManager::Mode prev = EyeProtectionManager::instance()->mode();
+    EyeProtectionManager::Mode next = (EyeProtectionManager::Off == prev)
+                                      ? EyeProtectionManager::Classic : EyeProtectionManager::Off;
+    // 触发构造函数中注册的护眼模式变化 lambda
+    EyeProtectionManager::instance()->setMode(next);
+    EyeProtectionManager::instance()->setMode(prev);
+    SUCCEED();
 }

--- a/tests/document/ut_djvumodel.cpp
+++ b/tests/document/ut_djvumodel.cpp
@@ -155,3 +155,9 @@ TEST_F(TestDjVuDocument, UT_TestDjVuDocument_searchAllPagesForText)
     }
     EXPECT_GT(searchesRun, 0);
 }
+
+TEST_F(TestDjVuDocument, UT_DjVuDocument_fileIdentifier_001)
+{
+    // 基类 Document::fileIdentifier 默认实现返回空串
+    EXPECT_TRUE(m_tester->fileIdentifier().isEmpty());
+}

--- a/tests/document/ut_pdfmodel.cpp
+++ b/tests/document/ut_pdfmodel.cpp
@@ -760,3 +760,9 @@ TEST_F(TestPDFDocument, UT_PDFDocument_loadDocument_001)
     EXPECT_TRUE(m_tester->loadDocument(filePath, password, error) == nullptr);
     EXPECT_TRUE(error == Document::WrongPassword);
 }
+
+TEST_F(TestPDFDocument, UT_PDFDocument_fileIdentifier_001)
+{
+    QString id1 = m_tester->fileIdentifier();
+    EXPECT_TRUE(id1 == m_tester->fileIdentifier());
+}

--- a/tests/eyeprotection/ut_eyeprotection.cpp
+++ b/tests/eyeprotection/ut_eyeprotection.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "EyeProtectionManager.h"
+#include "EyeProtectionAction.h"
+#include "RoundColorWidget.h"
+#include "SheetBrowser.h"
+
+#include <DWidget>
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+DWIDGET_USE_NAMESPACE
+
+/********测试EyeProtectionManager/EyeProtectionAction***********/
+class UT_EyeProtection : public ::testing::Test
+{
+public:
+    virtual void SetUp();
+
+    virtual void TearDown();
+
+protected:
+    DWidget *m_parent = nullptr;
+};
+
+void UT_EyeProtection::SetUp()
+{
+    m_parent = new DWidget;
+}
+
+void UT_EyeProtection::TearDown()
+{
+    EyeProtectionManager::instance()->setMode(EyeProtectionManager::Off);
+    delete m_parent;
+}
+
+TEST_F(UT_EyeProtection, UT_EyeProtectionManager_colors_001)
+{
+    EXPECT_TRUE(EyeProtectionManager::instance()->pageBackgroundColor().isValid());
+    EXPECT_TRUE(EyeProtectionManager::instance()->foregroundColor().isValid());
+}
+
+TEST_F(UT_EyeProtection, UT_EyeProtectionManager_setMode_001)
+{
+    QSignalSpy spy(EyeProtectionManager::instance(), &EyeProtectionManager::modeChanged);
+
+    EyeProtectionManager::instance()->setMode(EyeProtectionManager::Classic);
+    EXPECT_TRUE(EyeProtectionManager::instance()->mode() == EyeProtectionManager::Classic);
+    EXPECT_EQ(spy.count(), 1);
+
+    // 相同模式早退分支
+    EyeProtectionManager::instance()->setMode(EyeProtectionManager::Classic);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_EyeProtection, UT_EyeProtectionAction_onModeChanged_001)
+{
+    EyeProtectionAction action(m_parent);
+
+    EyeProtectionManager::instance()->setMode(EyeProtectionManager::Green);
+    action.onModeChanged(3);
+
+    RoundColorWidget *btn = action.defaultWidget()->findChild<RoundColorWidget *>("eye_2");
+    ASSERT_NE(btn, nullptr);
+    emit btn->clicked();    // initWidget 中 connect 的 lambda -> onBtnClicked
+    EXPECT_TRUE(EyeProtectionManager::instance()->mode() == EyeProtectionManager::Green);
+}
+
+TEST_F(UT_EyeProtection, UT_SheetBrowser_eyeModeLambda_001)
+{
+    SheetBrowser browser;
+    EyeProtectionManager::instance()->setMode(EyeProtectionManager::Night);
+    EXPECT_TRUE(EyeProtectionManager::instance()->mode() == EyeProtectionManager::Night);
+}

--- a/tests/sidebar/ut_catalogtreeview.cpp
+++ b/tests/sidebar/ut_catalogtreeview.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <QTest>
 #include <QListView>
+#include <QStandardItemModel>
 
 class TestCatalogTreeView : public ::testing::Test
 {
@@ -199,4 +200,27 @@ TEST_F(TestCatalogTreeView, testkeyPressEvent_direct)
     QKeyEvent event(QEvent::KeyPress, Qt::Key_Down, Qt::NoModifier);
     m_tester->keyPressEvent(&event);
     EXPECT_FALSE(m_tester->rightnotifypagechanged);
+}
+
+TEST_F(TestCatalogTreeView, testGetAndRestoreExpandedSections)
+{
+    QStandardItemModel *model = new QStandardItemModel(m_tester);
+    QStandardItem *root1 = new QStandardItem("Chapter1");
+    QStandardItem *child1 = new QStandardItem("Section1");
+    root1->appendRow(child1);
+    QStandardItem *root2 = new QStandardItem("Chapter2");
+    model->appendRow(root1);
+    model->appendRow(root2);
+    m_tester->setModel(model);
+
+    m_tester->expand(model->indexFromItem(root1));
+    QStringList sections = m_tester->getExpandedSections();
+    EXPECT_TRUE(sections.contains("Chapter1"));
+
+    // 空列表分支
+    m_tester->restoreExpandedSections(QStringList());
+
+    m_tester->collapseAll();
+    m_tester->restoreExpandedSections(sections);
+    EXPECT_TRUE(m_tester->isExpanded(model->indexFromItem(root1)));
 }

--- a/tests/sidebar/ut_catalogwidget.cpp
+++ b/tests/sidebar/ut_catalogwidget.cpp
@@ -86,3 +86,13 @@ TEST_F(UT_CatalogWidget, UT_CatalogWidget_pageUp)
     m_tester->pageUp();
     EXPECT_TRUE(m_tester->m_pTree != nullptr);
 }
+
+TEST_F(UT_CatalogWidget, UT_CatalogWidget_expandedSections_001)
+{
+    EXPECT_TRUE(m_tester->m_pTree != nullptr);
+    QStringList sections = m_tester->getExpandedSections();
+    EXPECT_TRUE(sections.isEmpty());
+    m_tester->restoreExpandedSections(QStringList());
+    m_tester->restoreExpandedSections(QStringList() << "Chapter1");
+    SUCCEED();
+}

--- a/tests/sidebar/ut_sheetsidebar.cpp
+++ b/tests/sidebar/ut_sheetsidebar.cpp
@@ -559,3 +559,11 @@ TEST_F(UT_SheetSidebar, UT_SheetSidebar_UT_SheetSidebar_sizeModeChanged)
     emit DGuiApplicationHelper::instance()->sizeModeChanged(DGuiApplicationHelper::NormalMode);
     EXPECT_TRUE(m_tester->m_sheet != nullptr);
 }
+
+TEST_F(UT_SheetSidebar, UT_SheetSidebar_expandedSections_001)
+{
+    QStringList sections = m_tester->getExpandedSections();
+    EXPECT_TRUE(sections.isEmpty());
+    m_tester->restoreExpandedSections(QStringList() << "Chapter1");
+    SUCCEED();
+}

--- a/tests/sidebar/ut_sidebarimagelistview.cpp
+++ b/tests/sidebar/ut_sidebarimagelistview.cpp
@@ -15,7 +15,10 @@
 #include <QListView>
 #include <QScroller>
 #include <QSignalSpy>
+#include <DGuiApplicationHelper>
 #include <QMenu>
+
+DGUI_USE_NAMESPACE
 
 class TestSideBarImageListView : public ::testing::Test
 {
@@ -234,4 +237,11 @@ TEST_F(TestSideBarImageListView, testkeyPressEvent)
     QTest::keyPress(m_tester, Qt::Key_PageUp);
     QTest::keyPress(m_tester, Qt::Key_PageDown);
     EXPECT_TRUE(m_tester->m_docSheet != nullptr);
+}
+
+TEST_F(TestSideBarImageListView, testThemeChanged_lambda)
+{
+    // 触发构造函数中注册的主题切换 lambda（刷新缩略图）
+    emit DGuiApplicationHelper::instance()->themeTypeChanged(DGuiApplicationHelper::LightType);
+    SUCCEED();
 }

--- a/tests/uiframe/ut_central.cpp
+++ b/tests/uiframe/ut_central.cpp
@@ -7,6 +7,7 @@
 #include "TitleMenu.h"
 #include "MainWindow.h"
 #include "CentralDocPage.h"
+#include "RestoreTipWidget.h"
 #include "ShortCutShow.h"
 #include "TitleWidget.h"
 #include "stub.h"
@@ -617,4 +618,24 @@ TEST_F(TestCentral, UT_Central_resizeEvent_001)
     m_tester->resizeEvent(event);
     EXPECT_TRUE(g_funcName == "resizeEvent_stub");
     delete event;
+}
+
+TEST_F(TestCentral, UT_Central_docPage_sigShowRestoreTip_lambda_001)
+{
+    CentralDocPage *docPage = m_tester->docPage();
+    ASSERT_NE(docPage, nullptr);
+    ASSERT_NE(m_tester->m_restoreTipWidget, nullptr);
+    // 无当前 sheet 分支
+    emit docPage->sigShowRestoreTip(nullptr);
+    SUCCEED();
+}
+
+TEST_F(TestCentral, UT_Central_jumpToFirstPage_lambda_001)
+{
+    m_tester->docPage();
+    RestoreTipWidget *tip = m_tester->m_restoreTipWidget;
+    ASSERT_NE(tip, nullptr);
+    // m_docPage 存在但当前无 sheet
+    emit tip->sigJumpToFirstPage();
+    SUCCEED();
 }

--- a/tests/uiframe/ut_centraldocpage.cpp
+++ b/tests/uiframe/ut_centraldocpage.cpp
@@ -1368,3 +1368,10 @@ TEST_F(TestCentralDocPage, UT_CentralDocPage_onCentralMoveIn_invoke)
 
 // Note: isFullScreen/openFullScreen require MainWindow in parent hierarchy
 // which is not available in this test fixture - skipping to avoid crash.
+
+TEST_F(TestCentralDocPage, UT_CentralDocPage_setActiveTabByFilePath_001)
+{
+    m_tester->setActiveTabByFilePath(QString());
+    m_tester->setActiveTabByFilePath("/tmp/ut_not_exist_active_file.pdf");
+    SUCCEED();
+}

--- a/tests/uiframe/ut_docsheet.cpp
+++ b/tests/uiframe/ut_docsheet.cpp
@@ -287,6 +287,11 @@ void showEncryPage_stub()
     g_funcName = __FUNCTION__;
 }
 
+static bool opened_stub_true()
+{
+    return true;
+}
+
 void wrongPassWordSlot_stub()
 {
     g_funcName = __FUNCTION__;
@@ -1119,6 +1124,84 @@ TEST_F(TestDocSheet, UT_DocSheet_onOpened_001)
     m_tester->onOpened(Document::NoError);
     EXPECT_TRUE(g_funcName == "handleOpenSuccess_stub");
 }
+
+TEST_F(TestDocSheet, UT_DocSheet_onOpened_restoreState_001)
+{
+    Stub s;
+    s.set(ADDR(SheetSidebar, handleOpenSuccess), handleOpenSuccess_stub);
+
+    // 触发 onOpened 中的三个恢复 lambda（滚动位置/目录展开/侧边栏宽度）
+    m_tester->m_password = "test";
+    m_tester->m_restoredFromState = true;
+    m_tester->m_operation.scrollPosition = 0.6f;
+    m_tester->m_operation.expandedSections << "Chapter1" << "Chapter1/Sub";
+    m_tester->m_operation.sidebarWidthChanged = true;
+    m_tester->m_operation.sidebarWidth = 80;
+
+    m_tester->onOpened(Document::NoError);
+    QTest::qWait(300);
+    SUCCEED();
+}
+
+TEST_F(TestDocSheet, UT_DocSheet_setSidebarWidth_001)
+{
+    m_tester->setSidebarWidth(250);
+    EXPECT_TRUE(m_tester->operation().sidebarWidth == 250);
+    EXPECT_TRUE(m_tester->operation().sidebarWidthChanged == true);
+}
+
+TEST_F(TestDocSheet, UT_DocSheet_currentScrollPosition_001)
+{
+    EXPECT_GE(m_tester->currentScrollPosition(), 0.0f);
+}
+
+TEST_F(TestDocSheet, UT_DocSheet_onAutoSave_001)
+{
+    m_tester->onAutoSave();
+    m_tester->m_sidebar->setVisible(true);
+    m_tester->onAutoSave();
+    SUCCEED();
+}
+
+TEST_F(TestDocSheet, UT_DocSheet_saveCurrentViewState_001)
+{
+    m_tester->m_sidebar->setVisible(true);
+    m_tester->saveCurrentViewState();
+    EXPECT_GE(m_tester->m_operation.sidebarWidth, 0);
+    SUCCEED();
+}
+
+static bool isVisible_stub_true()
+{
+    return true;
+}
+
+TEST_F(TestDocSheet, UT_DocSheet_restoreSavedViewState_001)
+{
+    Stub s;
+    s.set(ADDR(DocSheet, opened), opened_stub_true);
+    // 夹具中窗口链未 show（真实 show 会与后台渲染线程产生跨库干扰），
+    // 通过桩使 isVisible 为真以进入侧边栏宽度恢复分支
+    s.set(ADDR(QWidget, isVisible), isVisible_stub_true);
+
+    // 触发 restoreSavedViewState 中的两个恢复 lambda
+    m_tester->m_operation.sidebarWidthChanged = true;
+    m_tester->m_operation.sidebarWidth = 100;
+    m_tester->m_operation.scrollPosition = 0.5f;
+
+    m_tester->restoreSavedViewState();
+    QTest::qWait(250);
+    SUCCEED();
+}
+
+TEST_F(TestDocSheet, UT_DocSheet_splitterMoved_lambda_001)
+{
+    emit m_tester->splitterMoved(10, 1);     // 侧边栏隐藏分支
+    m_tester->m_sidebar->setVisible(true);
+    emit m_tester->splitterMoved(10, 1);     // 记录宽度分支
+    EXPECT_GE(m_tester->m_operation.sidebarWidth, 0);
+}
+
 
 TEST_F(TestDocSheet, UT_DocSheet_isFullScreen_001)
 {

--- a/tests/uiframe/ut_doctabbar.cpp
+++ b/tests/uiframe/ut_doctabbar.cpp
@@ -328,3 +328,19 @@ TEST_F(UT_DocTabBar, UT_DocTabBar_dragEnterEvent_emptyMime)
     m_tester->dragEnterEvent(&event);
     SUCCEED();
 }
+
+TEST_F(UT_DocTabBar, UT_DocTabBar_setPendingActiveFile_001)
+{
+    m_tester->setPendingActiveFile(QString());
+    EXPECT_TRUE(m_tester->m_delayIndex == -1);
+
+    m_tester->setPendingActiveFile("/tmp/ut_not_exist_file.pdf");
+    EXPECT_TRUE(m_tester->m_delayIndex == -1);
+
+    QString strPath = UTSOURCEDIR;
+    strPath += "/files/1.pdf";
+    DocSheet sheet(Dr::FileType::PDF, strPath, nullptr);
+    m_tester->insertSheet(&sheet);
+    m_tester->setPendingActiveFile(strPath);
+    EXPECT_TRUE(m_tester->m_delayIndex == 0);
+}

--- a/tests/ut_mainwindow.cpp
+++ b/tests/ut_mainwindow.cpp
@@ -266,3 +266,10 @@ TEST_F(TestMainWindow, testInitUILambdaSizeMode)
     emit helper->sizeModeChanged(DGuiApplicationHelper::NormalMode);
     SUCCEED();
 }
+
+TEST_F(TestMainWindow, UT_MainWindow_setInitialActiveFile_001)
+{
+    m_tester->setInitialActiveFile(QString());
+    m_tester->setInitialActiveFile("/tmp/ut_not_exist_active_file.pdf");
+    SUCCEED();
+}

--- a/tests/widgets/ut_restoretipwidget.cpp
+++ b/tests/widgets/ut_restoretipwidget.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "RestoreTipWidget.h"
+
+#include <QAbstractButton>
+#include <QPaintEvent>
+#include <QResizeEvent>
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+/********测试RestoreTipWidget***********/
+class UT_RestoreTipWidget : public ::testing::Test
+{
+public:
+    virtual void SetUp();
+
+    virtual void TearDown();
+
+protected:
+    QWidget *m_parent = nullptr;
+    RestoreTipWidget *m_tester = nullptr;
+};
+
+void UT_RestoreTipWidget::SetUp()
+{
+    m_parent = new QWidget;
+    m_parent->resize(800, 600);
+    m_parent->show();
+    m_tester = new RestoreTipWidget(m_parent);
+}
+
+void UT_RestoreTipWidget::TearDown()
+{
+    delete m_parent;
+}
+
+TEST_F(UT_RestoreTipWidget, initTest)
+{
+}
+
+TEST_F(UT_RestoreTipWidget, UT_RestoreTipWidget_showTip_001)
+{
+    m_tester->showTip();
+    EXPECT_FALSE(m_tester->isHidden());
+}
+
+TEST_F(UT_RestoreTipWidget, UT_RestoreTipWidget_paintEvent_001)
+{
+    QPaintEvent event(QRect(m_tester->rect()));
+    m_tester->paintEvent(&event);
+    EXPECT_FALSE(m_tester->grab().isNull());
+}
+
+TEST_F(UT_RestoreTipWidget, UT_RestoreTipWidget_resizeEvent_001)
+{
+    QResizeEvent event(QSize(400, 40), m_tester->size());
+    m_tester->resizeEvent(&event);      // 隐藏分支
+    m_tester->showTip();
+    m_tester->resizeEvent(&event);      // 可见分支 -> reposition
+    SUCCEED();
+}
+
+TEST_F(UT_RestoreTipWidget, UT_RestoreTipWidget_onFontChanged_001)
+{
+    m_tester->onFontChanged();
+    SUCCEED();
+}
+
+TEST_F(UT_RestoreTipWidget, UT_RestoreTipWidget_jumpBtnClicked_001)
+{
+    m_tester->showTip();
+    QSignalSpy spy(m_tester, SIGNAL(sigJumpToFirstPage()));
+    QAbstractButton *btn = m_tester->findChild<QAbstractButton *>("JumpBtn");
+    ASSERT_NE(btn, nullptr);
+    btn->click();
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_TRUE(m_tester->isHidden());
+}
+
+TEST_F(UT_RestoreTipWidget, UT_RestoreTipWidget_closeBtnClicked_001)
+{
+    m_tester->showTip();
+    QAbstractButton *btn = m_tester->findChild<QAbstractButton *>("CloseBtn");
+    ASSERT_NE(btn, nullptr);
+    btn->click();
+    EXPECT_TRUE(m_tester->isHidden());
+}

--- a/tests/widgets/ut_roundcolorwidget.cpp
+++ b/tests/widgets/ut_roundcolorwidget.cpp
@@ -7,6 +7,7 @@
 
 #include <QSignalSpy>
 #include "ut_compat.h"
+#include <QEnterEvent>
 
 #include <gtest/gtest.h>
 
@@ -64,4 +65,13 @@ TEST_F(UT_RoundColorWidget, UT_RoundColorWidget_paintEvent)
     QPaintEvent paint(QRect(m_tester->rect()));
     m_tester->paintEvent(&paint);
     EXPECT_FALSE(m_tester->grab().isNull());
+}
+
+TEST_F(UT_RoundColorWidget, UT_RoundColorWidget_enterLeaveEvent)
+{
+    QEnterEvent enter(QPointF(1, 1), QPointF(1, 1), QPointF(1, 1));
+    m_tester->enterEvent(&enter);
+    QEvent leave(QEvent::Leave);
+    m_tester->leaveEvent(&leave);
+    SUCCEED();
 }


### PR DESCRIPTION
Add new test suites for EyeProtectionManager/EyeProtectionAction and RestoreTipWidget; extend Database, DocSheet, sidebar and browser tests to cover tab group persistence, view state restore and theme lambdas.

新增护眼管理、恢复提示控件测试套件；补充数据库标签组持久化、
文档状态恢复、目录展开及主题切换 lambda 等测试用例。

Log: 补充单元测试用例
Influence: 仅新增/修改测试代码，不影响功能逻辑，提升测试覆盖率。

## Summary by Sourcery

Increase unit-test coverage for eye protection, restore-tip behavior, persisted tab groups, and document view-state restoration.

Enhancements:
- Expand unit-test coverage for database tab-group persistence and orphan-state cleanup.
- Cover document view-state saving and restoration, active-file selection, pending tabs, sidebar expansion and sizing, scrolling, and restore-tip interactions.
- Add dedicated tests for eye-protection management/actions, restore-tip widgets, and related UI event handling.
- Exercise browser image processing, document identifiers, catalog restoration, theme changes, and other UI lambdas and edge cases.

Tests:
- Add unit-test suites for EyeProtectionManager/EyeProtectionAction and RestoreTipWidget, while extending coverage across database, document, browser, sidebar, and UI-frame components.