### PR TITLE
chore: Update version to 6.5.60

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,34 @@
+deepin-reader (6.5.60) unstable; urgency=medium
+
+  * chore: Update version to 6.5.60
+  * test: add unit tests for eye protection, restore tip and view state
+  * fix(browser): guard async doc open task against stale sheet pointer
+  * fix: update Arabic (ar) translations
+  * test(at): stabilize deepin-reader AT yaml suites
+  * feat(widget): add hover border effect to RoundColorWidget
+  * feat: add AT-SPI accessible names for interactive widgets
+  * fix(restore): restore last active tab and scroll position
+  * feat(database): match state by document identifier and flush to disk
+  * style(widget): refine RestoreTipWidget appearance
+  * feat(eyeprotection): smart HSL luminance inversion for night mode
+  * docs(i18n): rename reading mode to eye protection mode in translations
+  * fix(sidebar): invert thumbnail luminance in dark theme
+  * fix: restore tip widget per-sheet state and multi-tab sync (#394181)
+  * feat: restore reading state with scroll position, sidebar width and tab group on startup
+  * fix(test): fix coverage collection failure in test-prj-running.sh
+  * refactor(tests): auto-discover reader sources and include dirs
+  * chore: Sync by https://github.com/linuxdeepin/.github/commit/a300f8523d4876677112edab6a0772f7ad112976
+  * chore: update translations for eye protection, restore and batch print
+  * feat: restore reading state with scroll position, catalog and tabs
+  * feat: add eye protection reading mode with four themes
+  * [skip CI] Translate deepin-reader.ts in pt
+  * feat(test): add ut-summary.json generation for test results and coverage
+  * test(at): fix AT-SPI yaml suites, 14/14 smoke pass
+  * [skip CI] Translate deepin-reader.ts in pt_BR
+  * test(at): stabilize deepin reader yaml suites
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Tue, 01 Sep 2026 10:34:04 +0800
+
 deepin-reader (6.5.59) unstable; urgency=medium
 
   * chore: Update version to 6.5.59

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.59.1
+  version: 6.5.60.1
   kind: app
   description: |
     reader for deepin os.


### PR DESCRIPTION
- update version to 6.5.60

log: update version to 6.5.60

## Summary by Sourcery

Chores:
- Update the Debian changelog and application package metadata for version 6.5.60.1.