### PR TITLE
fix(build): add missing sources and includes to qmake pri files

### DIFF
--- a/reader/document/document.pri
+++ b/reader/document/document.pri
@@ -6,7 +6,9 @@ HEADERS += \
 # XPS支持文件（条件包含）
 xps_support {
     HEADERS += $$PWD/XpsDocumentAdapter.h
+    HEADERS += $$PWD/XpsTextExtractor.h
     SOURCES += $$PWD/XpsDocumentAdapter.cpp
+    SOURCES += $$PWD/XpsTextExtractor.cpp
 }
 
 SOURCES += \

--- a/reader/eyeprotection/eyeprotection.pri
+++ b/reader/eyeprotection/eyeprotection.pri
@@ -1,0 +1,9 @@
+HEADERS += \
+    $$PWD/EyeProtectionManager.h \
+    $$PWD/EyeProtectionAction.h
+
+SOURCES += \
+    $$PWD/EyeProtectionManager.cpp \
+    $$PWD/EyeProtectionAction.cpp
+
+INCLUDEPATH += $$PWD

--- a/reader/src.pri
+++ b/reader/src.pri
@@ -4,6 +4,7 @@ INCLUDEPATH += $$PWD/widgets
 INCLUDEPATH += $$PWD/sidebar
 INCLUDEPATH += $$PWD/browser
 INCLUDEPATH += $$PWD/document
+INCLUDEPATH += $$PWD/eyeprotection
 
 include ($$PWD/app/app.pri)
 include ($$PWD/browser/browser.pri)
@@ -11,6 +12,7 @@ include ($$PWD/sidebar/sidebar.pri)
 include ($$PWD/widgets/widgets.pri)
 include ($$PWD/document/document.pri)
 include ($$PWD/uiframe/uiframe.pri)
+include ($$PWD/eyeprotection/eyeprotection.pri)
 
 SOURCES += \
     $$PWD/Application.cpp \

--- a/reader/widgets/widgets.pri
+++ b/reader/widgets/widgets.pri
@@ -14,6 +14,7 @@ HEADERS += \
     $$PWD/BaseWidget.h \
     $$PWD/TipsWidget.h \
     $$PWD/WordWrapLabel.h \
+    $$PWD/RestoreTipWidget.h \
     $$PWD/RoundColorWidget.h \
     $$PWD/TransparentTextEdit.h \
     $$PWD/TextEditWidget.h \
@@ -37,6 +38,7 @@ SOURCES += \
     $$PWD/BaseWidget.cpp \
     $$PWD/TipsWidget.cpp \
     $$PWD/WordWrapLabel.cpp \
+    $$PWD/RestoreTipWidget.cpp \
     $$PWD/RoundColorWidget.cpp \
     $$PWD/TransparentTextEdit.cpp \
     $$PWD/TextEditWidget.cpp \


### PR DESCRIPTION
## 问题

新增的护眼模块（eyeprotection）和 RestoreTipWidget 只更新了 CMakeLists.txt，qmake 工程文件（.pri）缺失对应源文件与头文件搜索路径，导致 qmake 构建失败：

- 编译错误：`fatal error: EyeProtectionManager.h: No such file or directory`
- 链接错误：`undefined reference to RestoreTipWidget::*`

## 修改内容

| 文件 | 改动 |
|---|---|
| reader/eyeprotection/eyeprotection.pri | 新增，声明护眼模块源文件与头文件 |
| reader/src.pri | 增加 eyeprotection 的 INCLUDEPATH 并 include 其 pri |
| reader/widgets/widgets.pri | 补上遗漏的 RestoreTipWidget.h/.cpp |
| reader/document/document.pri | xps_support 条件块补上遗漏的 XpsTextExtractor.h/.cpp（隐患预防） |

已对全部 7 个模块目录与 pri 列表做全量比对，无其他遗漏。

## 自测

`deb-builder-launcher.sh ll` 构建通过（4分2秒），产物 layer 导出成功。

【版本号】：deepin-reader > 6.5.60
【自测环境镜像版本】：V25
【代码地址】：本 PR
【根因分析】：新增文件只更新了 CMake 通配符自动收录的 CMakeLists.txt，漏改了 qmake 手写显式列表的 .pri 文件
【影响范围】：仅影响 qmake 构建，不改变代码逻辑
【自测结果截图/视频】：通过，见备注
【自测架构】: x86

## Summary by Sourcery

Update qmake project files so all required reader modules, headers, and sources are included during builds.

Bug Fixes:
- Fix qmake builds by registering the eye-protection module and previously omitted widget and XPS source files in the project configuration.

Build:
- Complete qmake include paths and source/header lists for newly added and conditionally compiled components.