### PR TITLE
chore: Update version to 6.5.61

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-reader (6.5.61) unstable; urgency=medium
+
+  * chore: Update version to 6.5.61
+  * fix(build): add missing sources and includes to qmake pri files
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Tue, 01 Sep 2026 13:06:10 +0800
+
 deepin-reader (6.5.60) unstable; urgency=medium
 
   * chore: Update version to 6.5.60

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.60.1
+  version: 6.5.61.1
   kind: app
   description: |
     reader for deepin os.


### PR DESCRIPTION
- update version to 6.5.61

log: update version to 6.5.61

## Summary by Sourcery

Chores:
- Update the Debian changelog and application package metadata for the 6.5.61 release.