### PR TITLE
fix(uiframe): save annotation immediately after operation

### DIFF
--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -1537,12 +1537,8 @@ void DocSheet::onBrowserOperaAnnotation(int type, int index, deepin_reader::Anno
     m_sidebar->handleAnntationMsg(type, index, anno);
     setDocumentChanged(true);
 
-    // 注释变化后立即触发自动保存（不等待 30 秒），确保尽快落盘
-    // 注意：不在 UI 回调中直接调 renderer->save()，因为 DPdfDoc::save()
-    // 会做整个 PDF 重写 + fsync，大文件会导致明显卡顿
-    // 使用 3 秒短间隔触发，兼顾及时落盘和 UI 流畅度
     if (m_autoSaveTimer) {
-        m_autoSaveTimer->start(3000);
+        m_autoSaveTimer->start(0);
     }
 }
 


### PR DESCRIPTION
Trigger the autosave timer with 0ms delay instead of 3s after any annotation operation, so note annotations are persisted to disk right away and survive a force-kill, just like highlights.

注释变化后立即触发自动保存（0毫秒定时器代替3秒延迟），确保注释
尽快落盘，进程被强制结束时不再丢失。

Log: 修复添加注释后立即强杀进程导致注释丢失的问题
PMS: BUG-375919
Influence: 添加/修改/删除注释后注释立即保存到文档，UI 行为与高亮一致。

## Summary by Sourcery

Bug Fixes:
- Save annotation changes immediately after add, edit, or delete operations so they are not lost if the process is force-terminated.