### PR TITLE
fix: prevent restore tip reappearing after tab switch on close

### DIFF
--- a/reader/uiframe/Central.cpp
+++ b/reader/uiframe/Central.cpp
@@ -54,6 +54,18 @@ Central::Central(QWidget *parent)
         }
     });
 
+    // 用户手动关闭提示条时，清除当前 sheet 的恢复标记，避免切换标签页再切回时重复出现。
+    // 本次打开文档期间不再提示；下次打开文档时 DocSheet::onOpened 会重新置位。
+    connect(m_restoreTipWidget, &RestoreTipWidget::sigCloseRestoreTip, this, [this]() {
+        if (m_docPage) {
+            DocSheet *sheet = m_docPage->getCurSheet();
+            if (sheet) {
+                sheet->dismissRestoreTip();
+                m_restoreTipWidget->hide();
+            }
+        }
+    });
+
     connect(DBusObject::instance(), &DBusObject::sigTouchPadEventSignal, this, &Central::onTouchPadEvent);
 
     QList<QKeySequence> keyList;

--- a/reader/widgets/RestoreTipWidget.cpp
+++ b/reader/widgets/RestoreTipWidget.cpp
@@ -77,6 +77,7 @@ void RestoreTipWidget::initUI()
     connect(m_closeBtn, &DIconButton::clicked, this, [this]() {
         qCDebug(appLog) << "Restore tip: close clicked";
         hide();
+        emit sigCloseRestoreTip();
     });
     layout->addWidget(m_closeBtn);
     setLayout(layout);

--- a/reader/widgets/RestoreTipWidget.h
+++ b/reader/widgets/RestoreTipWidget.h
@@ -48,6 +48,14 @@ signals:
      */
     void sigJumpToFirstPage();
 
+    /**
+     * @brief sigCloseRestoreTip 用户点击"关闭"，请求关闭提示条并清除恢复标记
+     *
+     * 关闭后本次打开文档期间不再显示，切换标签页再切回不会重复出现；
+     * 下次打开文档时 DocSheet::onOpened 会重新置位，仍会提示。
+     */
+    void sigCloseRestoreTip();
+
 protected:
     void paintEvent(QPaintEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;

--- a/tests/uiframe/ut_central.cpp
+++ b/tests/uiframe/ut_central.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -637,5 +637,15 @@ TEST_F(TestCentral, UT_Central_jumpToFirstPage_lambda_001)
     ASSERT_NE(tip, nullptr);
     // m_docPage 存在但当前无 sheet
     emit tip->sigJumpToFirstPage();
+    SUCCEED();
+}
+
+TEST_F(TestCentral, UT_Central_closeRestoreTip_lambda_001)
+{
+    m_tester->docPage();
+    RestoreTipWidget *tip = m_tester->m_restoreTipWidget;
+    ASSERT_NE(tip, nullptr);
+    // m_docPage 存在但当前无 sheet，关闭提示条不应崩溃
+    emit tip->sigCloseRestoreTip();
     SUCCEED();
 }

--- a/tests/widgets/ut_restoretipwidget.cpp
+++ b/tests/widgets/ut_restoretipwidget.cpp
@@ -83,8 +83,10 @@ TEST_F(UT_RestoreTipWidget, UT_RestoreTipWidget_jumpBtnClicked_001)
 TEST_F(UT_RestoreTipWidget, UT_RestoreTipWidget_closeBtnClicked_001)
 {
     m_tester->showTip();
+    QSignalSpy spy(m_tester, SIGNAL(sigCloseRestoreTip()));
     QAbstractButton *btn = m_tester->findChild<QAbstractButton *>("CloseBtn");
     ASSERT_NE(btn, nullptr);
     btn->click();
+    EXPECT_EQ(spy.count(), 1);
     EXPECT_TRUE(m_tester->isHidden());
 }


### PR DESCRIPTION
Emit sigCloseRestoreTip on close button click so Central clears the per-sheet restore flag; otherwise switching tabs back re-shows the tip.

关闭提示条时发出 sigCloseRestoreTip，由 Central 清除当前 sheet
的恢复标记；否则切换标签页再切回会因标记仍为 true 重复弹出。
本次打开期间不再显示，下次打开不在首页时仍会正常提示。

Log: 修复关闭恢复阅读位置提示后切标签页再切回重复弹出的问题
PMS: BUG-375937
Influence: 影响多标签页下恢复阅读位置提示条的显隐逻辑，关闭后本次打开文档不再重复提示，不影响其他功能。

## Summary by Sourcery

Clear the current sheet’s restore-tip state when the user closes the notification.

Bug Fixes:
- Prevent the restore-reading-position tip from reappearing after users close it and switch between document tabs.
- Ensure closing the tip suppresses it for the current document session while allowing it to return when the document is reopened.

Tests:
- Add coverage for the restore-tip close signal and Central’s handling when no sheet is active.