### PR TITLE
fix: prevent background sheet changes broadcasting sigCurSheetChanged

### DIFF
--- a/reader/uiframe/CentralDocPage.cpp
+++ b/reader/uiframe/CentralDocPage.cpp
@@ -191,7 +191,7 @@ void CentralDocPage::onSheetFileChanged(DocSheet *sheet)
         DBusObject::instance()->unBlockShutdown();
     }
 
-    if (nullptr == sheet && sheet != getCurSheet())
+    if (nullptr == sheet || sheet != getCurSheet())
         return;
 
     emit sigCurSheetChanged(sheet);
@@ -200,7 +200,7 @@ void CentralDocPage::onSheetFileChanged(DocSheet *sheet)
 void CentralDocPage::onSheetOperationChanged(DocSheet *sheet)
 {
     qCInfo(appLog) << "onSheetOperationChanged";
-    if (nullptr == sheet && sheet != getCurSheet())
+    if (nullptr == sheet || sheet != getCurSheet())
         return;
 
     emit sigCurSheetChanged(sheet);

--- a/tests/uiframe/ut_centraldocpage.cpp
+++ b/tests/uiframe/ut_centraldocpage.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -407,12 +407,17 @@ TEST_F(TestCentralDocPage, UT_CentralDocPage_onSheetFileChanged_001)
     QString strPath = UTSOURCEDIR;
     strPath += "/files/normal.pdf";
     DocSheet *sheet = new DocSheet(Dr::FileType::PDF, strPath, nullptr);
+    // 将 sheet 置为当前标签页，验证当前页变更时信号会发出
+    g_docsheet = sheet;
+    Stub s2;
+    s2.set(ADDR(CentralDocPage, getCurSheet), getCurSheet_stub2);
     QSignalSpy spy(m_tester, SIGNAL(sigCurSheetChanged(DocSheet *)));
 
     m_tester->onSheetFileChanged(sheet);
 
     EXPECT_TRUE(g_funcName == "blockShutdown_stub");
     EXPECT_TRUE(spy.count() == 1);
+    g_docsheet = nullptr;
     delete sheet;
 }
 
@@ -426,6 +431,10 @@ TEST_F(TestCentralDocPage, UT_CentralDocPage_onSheetFileChanged_002)
     QString strPath = UTSOURCEDIR;
     strPath += "/files/normal.pdf";
     DocSheet *sheet = new DocSheet(Dr::FileType::PDF, strPath, nullptr);
+    // 将 sheet 置为当前标签页，验证当前页变更时信号会发出
+    g_docsheet = sheet;
+    Stub s2;
+    s2.set(ADDR(CentralDocPage, getCurSheet), getCurSheet_stub2);
     QSignalSpy spy(m_tester, SIGNAL(sigCurSheetChanged(DocSheet *)));
 
     m_tester->onSheetFileChanged(sheet);
@@ -433,6 +442,7 @@ TEST_F(TestCentralDocPage, UT_CentralDocPage_onSheetFileChanged_002)
     EXPECT_TRUE(g_funcName == "unBlockShutdown_stub");
     EXPECT_TRUE(spy.count() == 1);
 
+    g_docsheet = nullptr;
     delete sheet;
 }
 
@@ -455,25 +465,82 @@ TEST_F(TestCentralDocPage, UT_CentralDocPage_onSheetFileChanged_003)
 
 TEST_F(TestCentralDocPage, UT_CentralDocPage_onSheetOperationChanged_001)
 {
-    Stub s;
-    s.set(ADDR(CentralDocPage, getCurSheet), getCurSheet_stub);
-
     QString strPath = UTSOURCEDIR;
     strPath += "/files/normal.pdf";
     DocSheet *sheet = nullptr;
 
     QSignalSpy spy(m_tester, SIGNAL(sigCurSheetChanged(DocSheet *)));
 
-    m_tester->onSheetFileChanged(sheet);
+    // 空指针不应发出信号
+    m_tester->onSheetOperationChanged(sheet);
     EXPECT_TRUE(spy.count() == 0);
 
+    // 当前标签页的变更应发出信号
     sheet = new DocSheet(Dr::FileType::PDF, strPath, nullptr);
-    m_tester->onSheetFileChanged(sheet);
+    g_docsheet = sheet;
+    Stub s;
+    s.set(ADDR(CentralDocPage, getCurSheet), getCurSheet_stub2);
+    m_tester->onSheetOperationChanged(sheet);
     EXPECT_TRUE(spy.count() == 1);
 
-    delete sheet;
-    delete g_docsheet;
     g_docsheet = nullptr;
+    delete sheet;
+}
+
+TEST_F(TestCentralDocPage, UT_CentralDocPage_onSheetOperationChanged_background)
+{
+    // 回归测试：后台标签页(非当前页)的操作变化不应触发 sigCurSheetChanged，
+    // 否则 ScaleWidget/ScaleMenu 会指向后台文档（最后一个打开的标签）
+    QString strPath = UTSOURCEDIR;
+    strPath += "/files/normal.pdf";
+    DocSheet *curSheet = new DocSheet(Dr::FileType::PDF, strPath, nullptr);
+    DocSheet *bgSheet = new DocSheet(Dr::FileType::PDF, strPath, nullptr);
+
+    g_docsheet = curSheet;   // 当前标签页是 curSheet
+    Stub s;
+    s.set(ADDR(CentralDocPage, getCurSheet), getCurSheet_stub2);
+    QSignalSpy spy(m_tester, SIGNAL(sigCurSheetChanged(DocSheet *)));
+
+    // 后台标签页操作变化：不应发出信号
+    m_tester->onSheetOperationChanged(bgSheet);
+    EXPECT_TRUE(spy.count() == 0);
+
+    // 当前标签页操作变化：应发出信号
+    m_tester->onSheetOperationChanged(curSheet);
+    EXPECT_TRUE(spy.count() == 1);
+
+    g_docsheet = nullptr;
+    delete bgSheet;
+    delete curSheet;
+}
+
+TEST_F(TestCentralDocPage, UT_CentralDocPage_onSheetFileChanged_background)
+{
+    // 回归测试：后台标签页的文件变更不应触发 sigCurSheetChanged
+    Stub s;
+    s.set(ADDR(DocSheet, existFileChanged), existFileChanged_stub_false);
+    s.set(ADDR(DBusObject, blockShutdown), blockShutdown_stub);
+    s.set(ADDR(DBusObject, unBlockShutdown), unBlockShutdown_stub);
+
+    QString strPath = UTSOURCEDIR;
+    strPath += "/files/normal.pdf";
+    DocSheet *curSheet = new DocSheet(Dr::FileType::PDF, strPath, nullptr);
+    DocSheet *bgSheet = new DocSheet(Dr::FileType::PDF, strPath, nullptr);
+
+    g_docsheet = curSheet;
+    Stub s2;
+    s2.set(ADDR(CentralDocPage, getCurSheet), getCurSheet_stub2);
+    QSignalSpy spy(m_tester, SIGNAL(sigCurSheetChanged(DocSheet *)));
+
+    m_tester->onSheetFileChanged(bgSheet);
+    EXPECT_TRUE(spy.count() == 0);
+
+    m_tester->onSheetFileChanged(curSheet);
+    EXPECT_TRUE(spy.count() == 1);
+
+    g_docsheet = nullptr;
+    delete bgSheet;
+    delete curSheet;
 }
 
 TEST_F(TestCentralDocPage, UT_CentralDocPage_addSheet_001)
@@ -1332,22 +1399,27 @@ TEST_F(TestCentralDocPage, UT_CentralDocPage_onSheetOperationChanged_invoke)
     strPath += "/files/normal.pdf";
     DocSheet *sheet = new DocSheet(Dr::FileType::PDF, strPath, nullptr);
 
+    // 将 sheet 置为当前标签页，验证当前页变更时信号会发出
+    g_docsheet = sheet;
+    Stub s;
+    s.set(ADDR(CentralDocPage, getCurSheet), getCurSheet_stub2);
     QSignalSpy spy(m_tester, SIGNAL(sigCurSheetChanged(DocSheet *)));
     m_tester->onSheetOperationChanged(sheet);
     EXPECT_TRUE(spy.count() == 1);
 
+    g_docsheet = nullptr;
     delete sheet;
 }
 
 TEST_F(TestCentralDocPage, UT_CentralDocPage_onSheetOperationChanged_nullptr)
 {
-    // nullptr sheet with no current sheet -> signal still emitted
+    // nullptr sheet -> 不再发出信号
     Stub s;
     s.set(ADDR(CentralDocPage, getCurSheet), getCurSheet_stub_nullptr);
 
     QSignalSpy spy(m_tester, SIGNAL(sigCurSheetChanged(DocSheet *)));
     m_tester->onSheetOperationChanged(nullptr);
-    EXPECT_TRUE(spy.count() == 1);
+    EXPECT_TRUE(spy.count() == 0);
 }
 
 TEST_F(TestCentralDocPage, UT_CentralDocPage_onCentralMoveIn_invoke)

--- a/tests/uiframe/ut_scalemenu_repro.cpp
+++ b/tests/uiframe/ut_scalemenu_repro.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 临时复现测试：多标签页打开时 ScaleWidget/ScaleMenu 是否指向当前标签页文档
+
+#include "Central.h"
+#include "CentralDocPage.h"
+#include "TitleWidget.h"
+#include "ScaleWidget.h"
+#include "DocSheet.h"
+#include "DocTabBar.h"
+#include "ut_defines.h"
+
+#include <QStackedLayout>
+#include <QTimer>
+#include <QEventLoop>
+
+#include <gtest/gtest.h>
+
+static void processEvents(int ms)
+{
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+// 模拟用户点击标签栏第 idx 个标签（与鼠标点击一致：DTabBar 内部即 setCurrentIndex）
+static void clickTab(CentralDocPage *docPage, int idx)
+{
+    DocTabBar *bar = docPage->m_tabBar;
+    ASSERT_NE(bar, nullptr);
+    ASSERT_TRUE(idx >= 0 && idx < bar->count());
+    bar->setCurrentIndex(idx);   // 与用户点击等价，触发 currentChanged
+}
+
+static DocSheet *scaleMenuTarget(Central *central)
+{
+    return central->titleWidget()->m_pSw->m_sheet.data();
+}
+
+// 场景1：一次打开多个文档，等全部加载完，切到第一个标签
+TEST(TestScaleMenuRepro, batchOpenThenSwitch)
+{
+    QWidget w;
+    Central central(&w);
+
+    central.addFileAsync(QString(UTSOURCEDIR) + "/files/1.pdf");
+    central.addFileAsync(QString(UTSOURCEDIR) + "/files/2.pdf");
+    central.addFileAsync(QString(UTSOURCEDIR) + "/files/3.pdf");
+    processEvents(1500);
+
+    CentralDocPage *docPage = central.docPage();
+    QList<DocSheet *> sheets = docPage->getSheets();
+    ASSERT_EQ(sheets.size(), 3);
+
+    clickTab(docPage, 0);
+    processEvents(300);
+    EXPECT_EQ(docPage->getCurSheet(), sheets[0]);
+    qDebug() << "[case1] after click tab0, scale target =" << (scaleMenuTarget(&central) ? scaleMenuTarget(&central)->filePath() : "null");
+    EXPECT_EQ(scaleMenuTarget(&central), sheets[0]);
+}
+
+// 场景2：打开多个文档，加载未完成时立即切换标签（更贴近真实操作）
+TEST(TestScaleMenuRepro, switchWhileLoading)
+{
+    QWidget w;
+    Central central(&w);
+
+    central.addFileAsync(QString(UTSOURCEDIR) + "/files/1.pdf");
+    central.addFileAsync(QString(UTSOURCEDIR) + "/files/2.pdf");
+    // 不等待，立即点击第一个标签（模拟加载过程中切换）
+    processEvents(5);          // 让 1ms 延时的 setCurrentIndex 触发
+    clickTab(central.docPage(), 0);
+
+    // 等待所有文档异步加载完成
+    processEvents(2000);
+
+    CentralDocPage *docPage = central.docPage();
+    QList<DocSheet *> sheets = docPage->getSheets();
+    ASSERT_EQ(sheets.size(), 2);
+    EXPECT_EQ(docPage->getCurSheet(), sheets[0]);
+    qDebug() << "[case2] after load complete, cur =" << docPage->getCurSheet()->filePath()
+             << ", scale target =" << (scaleMenuTarget(&central) ? scaleMenuTarget(&central)->filePath() : "null");
+    EXPECT_EQ(scaleMenuTarget(&central), sheets[0]);
+}
+
+// 场景3：逐个打开文档（每次打开后等加载完成再打开下一个），再切换标签
+TEST(TestScaleMenuRepro, sequentialOpenThenSwitch)
+{
+    QWidget w;
+    Central central(&w);
+
+    central.addFileAsync(QString(UTSOURCEDIR) + "/files/1.pdf");
+    processEvents(1000);
+    central.addFileAsync(QString(UTSOURCEDIR) + "/files/2.pdf");
+    processEvents(1000);
+
+    CentralDocPage *docPage = central.docPage();
+    QList<DocSheet *> sheets = docPage->getSheets();
+    ASSERT_EQ(sheets.size(), 2);
+
+    clickTab(docPage, 0);
+    processEvents(300);
+    EXPECT_EQ(docPage->getCurSheet(), sheets[0]);
+    qDebug() << "[case3] after click tab0, cur=" << docPage->getCurSheet()->filePath()
+             << ", scale target =" << (scaleMenuTarget(&central) ? scaleMenuTarget(&central)->filePath() : "null");
+    EXPECT_EQ(scaleMenuTarget(&central), sheets[0]);
+}


### PR DESCRIPTION
The old condition `nullptr == sheet && sheet != getCurSheet()` never filtered background tabs, so any file/operation change of a hidden tab still emitted sigCurSheetChanged, making ScaleWidget/TitleMenu follow the last opened document instead of the visible one. Use `||` so only changes of the current sheet are broadcast.

原条件用 && 判断，后台标签页的文件/操作变化仍会广播 sigCurSheetChanged，
导致 ScaleWidget/标题菜单指向最后打开的后台文档。改为 || 后仅当前文档
的变化才会广播。

Log: 修复后台标签页变化误广播当前文档切换信号的问题
PMS: BUG-375907
Influence: 多标签页下缩放菜单与标题栏始终跟随当前可见文档，后台文档变化不再干扰界面状态。

## Summary by Sourcery

Restrict current-sheet change notifications to the active document and add multi-tab regression coverage.

Bug Fixes:
- Prevent background or null document changes from emitting sigCurSheetChanged, ensuring UI state follows only the visible document.

Tests:
- Add regression coverage for current, background, and null sheet changes, plus multi-tab ScaleWidget and title menu behavior.