### PR TITLE
fix(database): clear expired network document state after 7 days

### DIFF
--- a/reader/app/Database.cpp
+++ b/reader/app/Database.cpp
@@ -26,6 +26,9 @@
 #include <QJsonArray>
 #include <QJsonValue>
 
+// 网络文档阅读状态的保留时长：超过该天数未打开则视为过期，启动时清理
+static constexpr int kNetworkStateTimeoutDays = 7;
+
 Transaction::Transaction(QSqlDatabase &database)
     : m_committed(false), m_database(database)
 {
@@ -94,6 +97,7 @@ bool Database::prepareOperation()
                     ",lastModified INTEGER DEFAULT 0"
                     ",contentHash TEXT DEFAULT ''"
                     ",docId TEXT DEFAULT ''"
+                    ",lastOpened INTEGER DEFAULT 0"
                     ")")) {
         qCInfo(appLog) << query.lastError();
         return false;
@@ -138,7 +142,8 @@ bool Database::migrateOperationTable()
         {"fileSize",       "INTEGER DEFAULT 0"},
         {"lastModified",   "INTEGER DEFAULT 0"},
         {"contentHash",    "TEXT DEFAULT ''"},
-        {"docId",          "TEXT DEFAULT ''"}
+        {"docId",          "TEXT DEFAULT ''"},
+        {"lastOpened",     "INTEGER DEFAULT 0"}
     };
 
     Transaction transaction(m_database);
@@ -198,6 +203,16 @@ bool Database::readOperation(DocSheet *sheet)
                 sheet->m_operation.expandedSections.append(val.toString());
             }
         }
+        // 网络文档：命中即刷新打开时间，作为 7 天超时清理的时间基准
+        if (Dr::isNetworkPath(sheet->filePath())) {
+            QSqlQuery touchQuery(m_database);
+            touchQuery.prepare("UPDATE operation SET lastOpened = :lastOpened WHERE filePath = :filePath");
+            touchQuery.bindValue(":lastOpened", QDateTime::currentMSecsSinceEpoch());
+            touchQuery.bindValue(":filePath", sheet->filePath());
+            if (!touchQuery.exec()) {
+                qCWarning(appLog) << "Failed to update lastOpened:" << touchQuery.lastError();
+            }
+        }
         return true;
     }
     return false;
@@ -224,10 +239,10 @@ bool Database::saveOperation(DocSheet *sheet, const QString &cachedContentHash)
     query.prepare("REPLACE INTO "
                   "operation(filePath,layoutMode,mouseShape,scaleMode,rotation,scaleFactor,"
                   "sidebarVisible,sidebarIndex,currentPage,sidebarWidth,sidebarWidthChanged,scrollPosition,expandedSections,"
-                  "fileSize,lastModified,contentHash,docId)"
+                  "fileSize,lastModified,contentHash,docId,lastOpened)"
                   " VALUES(:filePath,:layoutMode,:mouseShape,:scaleMode,:rotation,:scaleFactor,"
                   ":sidebarVisible,:sidebarIndex,:currentPage,:sidebarWidth,:sidebarWidthChanged,:scrollPosition,:expandedSections,"
-                  ":fileSize,:lastModified,:contentHash,:docId)");
+                  ":fileSize,:lastModified,:contentHash,:docId,:lastOpened)");
     query.bindValue(":filePath", sheet->filePath());
     query.bindValue(":layoutMode", sheet->m_operation.layoutMode);
     query.bindValue(":mouseShape", sheet->m_operation.mouseShape);
@@ -251,6 +266,7 @@ bool Database::saveOperation(DocSheet *sheet, const QString &cachedContentHash)
     query.bindValue(":lastModified", lastModified);
     query.bindValue(":contentHash", contentHash);
     query.bindValue(":docId", docId);
+    query.bindValue(":lastOpened", QDateTime::currentMSecsSinceEpoch());
 
     if (!query.exec()) {
         qCInfo(appLog) << query.lastError().text();
@@ -366,9 +382,10 @@ bool Database::matchOperationByContent(const QFileInfo &fileInfo, DocSheet *shee
 
     // 更新文件路径为新路径（在同一事务中保证原子性）
     QSqlQuery updateQuery(m_database);
-    updateQuery.prepare("UPDATE operation SET filePath = :newPath WHERE filePath = :oldPath");
+    updateQuery.prepare("UPDATE operation SET filePath = :newPath, lastOpened = :lastOpened WHERE filePath = :oldPath");
     updateQuery.bindValue(":newPath", fileInfo.absoluteFilePath());
     updateQuery.bindValue(":oldPath", oldFilePath);
+    updateQuery.bindValue(":lastOpened", QDateTime::currentMSecsSinceEpoch());
     if (!updateQuery.exec()) {
         qCWarning(appLog) << "Failed to update file path after content match:" << updateQuery.lastError();
     }
@@ -390,16 +407,28 @@ int Database::cleanupOrphanStates()
 {
     qCDebug(appLog) << "Starting orphan state cleanup";
     QSqlQuery query(m_database);
-    if (!query.exec("SELECT filePath FROM operation")) {
+    // 同时取出 lastOpened，用于网络文档的 7 天超时判断
+    if (!query.exec("SELECT filePath, lastOpened FROM operation")) {
         qCWarning(appLog) << "Failed to query operations for cleanup:" << query.lastError();
         return 0;
     }
 
+    // 网络文档状态的超时时间（毫秒）
+    const qint64 networkTimeoutMs = qint64(kNetworkStateTimeoutDays) * 24 * 60 * 60 * 1000;
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+
     QStringList orphanPaths;
     while (query.next()) {
         QString filePath = query.value("filePath").toString();
-        // 网络路径暂不清理
         if (Dr::isNetworkPath(filePath)) {
+            // 网络路径：挂载状态不可靠（QFile::exists() 无法判断文件是否仍存在），
+            // 改用超时策略——超过 7 天未打开的网络文档状态记录视为过期，连同书签一起清理
+            const qint64 lastOpened = query.value("lastOpened").toLongLong();
+            if (lastOpened > 0 && now - lastOpened > networkTimeoutMs) {
+                qCInfo(appLog) << "Network document state expired (lastOpened"
+                                << QDateTime::fromMSecsSinceEpoch(lastOpened).toString() << "):" << filePath;
+                orphanPaths.append(filePath);
+            }
             continue;
         }
         if (!QFile::exists(filePath)) {

--- a/reader/app/Database.h
+++ b/reader/app/Database.h
@@ -117,7 +117,8 @@ public:
 
     /**
      * @brief cleanupOrphanStates
-     * 清理已不存在的文档对应的状态记录
+     * 清理已不存在的本地文档对应的状态记录；
+     * 网络文档按超时清理：超过 7 天未打开的记录（含书签）被清除
      * @return 清理的记录数
      */
     int cleanupOrphanStates();

--- a/reader/app/Global.cpp
+++ b/reader/app/Global.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 -2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -60,6 +60,12 @@ FileType fileType(const QString &filePath)
 
 bool isNetworkPath(const QString &filePath)
 {
+    // gvfs（smb/nfs 等用户态挂载）路径特征明确，先按字符串判断。
+    // 挂载断开后目录不存在，QStorageInfo 会返回无效而被误判为本地路径，
+    // 导致后续状态清理逻辑无法按网络文档的超时策略处理
+    if (filePath.startsWith("/run/user/") && filePath.contains("/gvfs/"))
+        return true;
+
     const QStorageInfo storage(filePath);
     if (!storage.isValid() || storage.isRoot())
         return false;
@@ -68,9 +74,6 @@ bool isNetworkPath(const QString &filePath)
     if (fsType.contains("nfs") || fsType.contains("cifs") ||
         fsType.contains("smb") || fsType.contains("sshfs") ||
         fsType.contains("gvfsd"))
-        return true;
-
-    if (filePath.startsWith("/run/user/") && filePath.contains("/gvfs/"))
         return true;
 
     return false;

--- a/reader/main.cpp
+++ b/reader/main.cpp
@@ -108,6 +108,9 @@ int main(int argc, char *argv[])
         return 0;
     }
 
+    // 启动时清理失效的状态记录
+    Database::instance()->cleanupOrphanStates();
+
     // 这是第一个实例（没有其他 deepin-reader 在运行），恢复上次的标签页组
     // 不管命令行是否指定了文件，都恢复之前的标签页
     // 注意：当前仅恢复 windowIndex=0 的标签页组（多窗口场景的完整恢复待后续优化）

--- a/tests/app/ut_database.cpp
+++ b/tests/app/ut_database.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 
 #include <QTest>
 #include <QSqlQuery>
+#include <QDateTime>
 
 #include <gtest/gtest.h>
 
@@ -187,4 +188,92 @@ TEST_F(TestDatabase, UT_Database_cleanupOrphanStates_001)
     EXPECT_GE(cleaned, 1);
     // 孤儿记录已被清理，再次执行返回 0
     EXPECT_EQ(m_tester->cleanupOrphanStates(), 0);
+}
+
+// 构造 gvfs 网络路径（isNetworkPath 通过字符串前缀识别，无需真实网络挂载）
+static QString ut_network_path(const QString &name)
+{
+    return QString("/run/user/1000/gvfs/smb-share:server=ut,share=share/%1").arg(name);
+}
+
+static qint64 ut_operation_count(Database *db, const QString &filePath)
+{
+    QSqlQuery query(db->m_database);
+    query.prepare("SELECT COUNT(*) FROM operation WHERE filePath = :p");
+    query.bindValue(":p", filePath);
+    query.exec();
+    query.next();
+    return query.value(0).toLongLong();
+}
+
+static qint64 ut_bookmark_count(Database *db, const QString &filePath)
+{
+    QSqlQuery query(db->m_database);
+    query.prepare("SELECT COUNT(*) FROM bookmark WHERE filePath = :p");
+    query.bindValue(":p", filePath);
+    query.exec();
+    query.next();
+    return query.value(0).toLongLong();
+}
+
+TEST_F(TestDatabase, UT_Database_cleanupOrphanStates_002)
+{
+    // 网络文档超时清理：lastOpened 超过 7 天的记录及书签应被清理
+    QString netPath = ut_network_path("expired.pdf");
+    DocSheet netSheet(Dr::FileType::PDF, netPath, nullptr);
+    ASSERT_TRUE(m_tester->saveOperation(&netSheet));
+    QSet<int> bookmarks {1, 5, 9};
+    ASSERT_TRUE(m_tester->saveBookmarks(netPath, bookmarks));
+
+    // 手动将 lastOpened 设置为 8 天前
+    qint64 oldTime = QDateTime::currentMSecsSinceEpoch() - 8LL * 24 * 60 * 60 * 1000;
+    QSqlQuery update(m_tester->m_database);
+    update.prepare("UPDATE operation SET lastOpened = :t WHERE filePath = :p");
+    update.bindValue(":t", oldTime);
+    update.bindValue(":p", netPath);
+    ASSERT_TRUE(update.exec());
+
+    int cleaned = m_tester->cleanupOrphanStates();
+    EXPECT_GE(cleaned, 1);
+
+    // operation 与 bookmark 记录均已被清理
+    EXPECT_EQ(ut_operation_count(m_tester, netPath), 0);
+    EXPECT_EQ(ut_bookmark_count(m_tester, netPath), 0);
+}
+
+TEST_F(TestDatabase, UT_Database_cleanupOrphanStates_003)
+{
+    // 网络文档未超时：lastOpened 在 7 天内的记录应保留
+    // （测试共用数据库可能存在其他历史孤儿记录，不校验返回值，
+    //   仅验证本记录未被清理）
+    QString netPath = ut_network_path("fresh.pdf");
+    DocSheet netSheet(Dr::FileType::PDF, netPath, nullptr);
+    ASSERT_TRUE(m_tester->saveOperation(&netSheet));
+    QSet<int> bookmarks {2};
+    ASSERT_TRUE(m_tester->saveBookmarks(netPath, bookmarks));
+
+    m_tester->cleanupOrphanStates();
+
+    EXPECT_EQ(ut_operation_count(m_tester, netPath), 1);
+    EXPECT_EQ(ut_bookmark_count(m_tester, netPath), 1);
+}
+
+TEST_F(TestDatabase, UT_Database_lastOpened_001)
+{
+    // saveOperation 应写入 lastOpened 时间戳
+    QString path = "/tmp/deepin_reader_ut_lastopened.pdf";
+    DocSheet sheet(Dr::FileType::PDF, path, nullptr);
+    ASSERT_TRUE(m_tester->saveOperation(&sheet));
+
+    QSqlQuery query(m_tester->m_database);
+    query.prepare("SELECT lastOpened FROM operation WHERE filePath = :p");
+    query.bindValue(":p", path);
+    ASSERT_TRUE(query.exec());
+    ASSERT_TRUE(query.next());
+
+    qint64 lastOpened = query.value(0).toLongLong();
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    // 时间戳在 1 分钟以内视为有效
+    EXPECT_GT(lastOpened, now - 60 * 1000);
+    EXPECT_LE(lastOpened, now);
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,10 +1,14 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "Application.h"
 #include "ut_defines.h"
 #include "Application.h"
+
+#include <QStandardPaths>
+#include <QDir>
+#include <QFile>
 
 #include <gtest/gtest.h>
 
@@ -18,7 +22,17 @@ int main(int argc, char *argv[])
 {
     qputenv("QT_QPA_PLATFORM", "offscreen");
 
+    // 单元测试与业务数据隔离：将 QStandardPaths 重定向到测试目录(~/.qttest)，
+    QStandardPaths::setTestModeEnabled(true);
+
     Application application(argc, argv);
+
+    // 清理上次测试残留的数据库，保证用例从干净状态开始
+    const QString utDataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir().mkpath(utDataDir);
+    QFile::remove(QDir(utDataDir).filePath("user.db"));
+    QFile::remove(QDir(utDataDir).filePath("user.db-wal"));
+    QFile::remove(QDir(utDataDir).filePath("user.db-shm"));
 
     ::testing::InitGoogleTest(&argc, argv);
 


### PR DESCRIPTION
Network documents were never cleaned up: the operation table had no "last opened" timestamp, cleanupOrphanStates skipped network paths and was never invoked at startup. Record lastOpened on save, read and content-match; expire network records (with bookmarks) after 7 days and run cleanup on startup. Also fix isNetworkPath misdetecting unmounted gvfs paths as local, which deleted their state instantly.

网络文档状态此前不会被清理：operation 表缺少"最后打开时间"字段，
cleanupOrphanStates 跳过网络路径且启动时从未被调用。现于保存、读取、
内容匹配时记录 lastOpened，网络文档超过 7 天未打开则连同书签一起
清理，并在启动时执行清理。同时修复 isNetworkPath 将已断开的 gvfs
挂载误判为本地路径导致状态被立即删除的问题。

Log: 网络文档阅读状态与书签支持7天超时自动清理
PMS: BUG-376083
Influence: 网络文档（SMB/NFS/gvfs）的阅读状态与书签超过7天未打开后自动清理；本地孤儿状态清理在启动时生效；单元测试改用隔离数据库，不再读写真实用户数据。

## Summary by Sourcery

Automatically clean up stale document state while preserving recently used network-document state.

New Features:
- Track when document state was last opened and automatically expire network-document state and bookmarks after seven days without access.

Bug Fixes:
- Correctly classify disconnected GVFS paths as network documents so their state is not removed as a local orphan immediately.

Enhancements:
- Run orphan and expired-state cleanup during application startup.

Tests:
- Add coverage for expiration and retention of network-document state and verification of last-opened timestamps.
- Isolate database unit tests from real user data by using test-mode application paths and resetting the test database before execution.