### PR TITLE
fix: save reading progress along with bookmark operations

### DIFF
--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -400,6 +400,8 @@ void DocSheet::setBookMark(int index, int state)
 
     m_browser->setBookMark(index, state);
 
+    saveProgressToDb();
+
     Database::instance()->saveBookmarks(filePath(), m_bookmarks);
     Database::instance()->flushToDisk();
     m_bookmarkChanged = false;
@@ -425,6 +427,8 @@ void DocSheet::setBookMarks(const QList<int> &indexlst, int state)
 
     if (!state)
         showTips(tr("The bookmark has been removed"));
+
+    saveProgressToDb();
 
     Database::instance()->saveBookmarks(filePath(), m_bookmarks);
     Database::instance()->flushToDisk();
@@ -2030,10 +2034,8 @@ void DocSheet::LoadingWidget::paintEvent(QPaintEvent *)
     // qCDebug(appLog) << "paintEvent end";
 }
 
-void DocSheet::onAutoSave()
+void DocSheet::saveProgressToDb()
 {
-    qCDebug(appLog) << "Auto-save triggered for:" << m_filePath;
-
     // 更新滚动位置
     if (m_browser) {
         m_operation.scrollPosition = m_browser->getScrollPosition();
@@ -2045,11 +2047,18 @@ void DocSheet::onAutoSave()
         m_operation.expandedSections = m_sidebar->getExpandedSections();
     }
 
-    // 自动保存时使用缓存哈希，避免每30秒读盘计算
+    // 使用缓存哈希，避免读盘计算；无缓存时刷新一次并缓存
     if (m_cachedContentHash.isEmpty()) {
         m_cachedContentHash = Database::computeContentHash(m_filePath);
     }
     Database::instance()->saveOperation(this, m_cachedContentHash);
+}
+
+void DocSheet::onAutoSave()
+{
+    qCDebug(appLog) << "Auto-save triggered for:" << m_filePath;
+
+    saveProgressToDb();
 
     // 兜底保存书签（正常情况 setBookMark 已立即落盘，此处分防其他路径设的脏标记）
     if (m_bookmarkChanged) {

--- a/reader/uiframe/DocSheet.h
+++ b/reader/uiframe/DocSheet.h
@@ -641,6 +641,13 @@ public:
     void saveCurrentViewState();
 
     /**
+     * @brief 将当前阅读进度立即写入数据库
+     * 更新滚动位置/侧栏状态到 m_operation 并执行 saveOperation。
+     * 供书签等已有即时落盘的操作顺带保存进度，异常退出（如 killall）后进度不丢。
+     */
+    void saveProgressToDb();
+
+    /**
      * @brief needsRestoreTip 该 sheet 是否仍需要显示恢复阅读位置提示条
      */
     bool needsRestoreTip() const;


### PR DESCRIPTION
Reading progress was only persisted on close/tab switch/30s auto-save, so killing the process (killall) lost the last position while bookmarks survived. Extract saveProgressToDb() and call it in setBookMark/ setBookMarks so progress is flushed together with bookmarks. Annotation/highlight ops already trigger immediate auto-save via m_autoSaveTimer->start(0) and need no change.

阅读进度此前仅在关闭/切标签/30秒自动保存时落盘，killall 异常退出会
丢失进度而书签已保存。抽出 saveProgressToDb() 并在添加/批量添加书签时
调用，进度随书签一并落盘；高亮/注释已通过 start(0) 即时保存，无需修改。

Log: 书签操作时顺带保存阅读进度，异常退出后进度不丢
PMS: BUG-375907
Influence: 添加/删除书签时当前阅读进度立即写入数据库并落盘；正常关闭流程行为不变。

## Summary by Sourcery

Persist current reading progress alongside bookmark changes so bookmark operations also protect the latest reading position.

Bug Fixes:
- Persist reading progress immediately when adding or removing bookmarks, preventing the latest position from being lost after abnormal application termination.

Enhancements:
- Reuse a dedicated reading-progress persistence operation for bookmark actions and periodic auto-save while preserving the existing close and auto-save behavior.