### PR TITLE
fix(database): verify content hash before restoring bookmarks and state

### DIFF
--- a/reader/app/Database.cpp
+++ b/reader/app/Database.cpp
@@ -112,6 +112,40 @@ bool Database::prepareOperation()
     return true;
 }
 
+bool Database::migrateBookmarkTable()
+{
+    qCDebug(appLog) << "Checking if bookmark table needs migration";
+    QSqlQuery query(m_database);
+
+    if (!query.exec("PRAGMA table_info(bookmark)")) {
+        qCWarning(appLog) << "Failed to get bookmark table info:" << query.lastError();
+        return false;
+    }
+
+    QSet<QString> existingColumns;
+    while (query.next()) {
+        existingColumns.insert(query.value("name").toString());
+    }
+
+    if (existingColumns.contains("contentHash")) {
+        return true;
+    }
+
+    Transaction transaction(m_database);
+    if (!query.exec("ALTER TABLE bookmark ADD COLUMN contentHash TEXT DEFAULT ''")) {
+        QString errorText = query.lastError().text();
+        if (errorText.contains("duplicate column name", Qt::CaseInsensitive)) {
+            qCDebug(appLog) << "Column already exists, skipping: contentHash";
+        } else {
+            qCWarning(appLog) << "Failed to add contentHash column to bookmark:" << errorText;
+        }
+    } else {
+        qCInfo(appLog) << "Migrating bookmark table: added contentHash column";
+    }
+    transaction.commit();
+    return true;
+}
+
 bool Database::migrateOperationTable()
 {
     qCDebug(appLog) << "Checking if operation table needs migration";
@@ -182,6 +216,19 @@ bool Database::readOperation(DocSheet *sheet)
         qCWarning(appLog) << "Failed to read operation:" << query.lastError();
     }
     if (query.next()) {
+        // 内容指纹校验：同名路径下换了文件（删除重命名、覆盖等）不应继承旧文档的阅读状态。
+        // 校验不过则删除过期记录，让后续的 matchOperationByContent 有机会恢复新文档自己的状态
+        const QString currentHash = computeContentHash(sheet->filePath());
+        const QString recordHash = query.value("contentHash").toString();
+        if (!currentHash.isEmpty() && !recordHash.isEmpty() && recordHash != currentHash) {
+            qCInfo(appLog) << "Stale operation dropped (content mismatch):" << sheet->filePath();
+            QSqlQuery delQuery(m_database);
+            delQuery.prepare("DELETE FROM operation WHERE filePath = :filePath");
+            delQuery.bindValue(":filePath", sheet->filePath());
+            delQuery.exec();
+            return false;
+        }
+
         sheet->m_operation.layoutMode = static_cast<Dr::LayoutMode>(query.value("layoutMode").toInt());
         sheet->m_operation.mouseShape = static_cast<Dr::MouseShape>(query.value("mouseShape").toInt());
         sheet->m_operation.scaleMode = static_cast<Dr::ScaleMode>(query.value("scaleMode").toInt());
@@ -203,6 +250,17 @@ bool Database::readOperation(DocSheet *sheet)
                 sheet->m_operation.expandedSections.append(val.toString());
             }
         }
+        // 旧版本记录（无指纹）读取时回填，后续打开即可校验
+        if (!currentHash.isEmpty() && recordHash.isEmpty()) {
+            QSqlQuery backfill(m_database);
+            backfill.prepare("UPDATE operation SET contentHash = :contentHash WHERE filePath = :filePath");
+            backfill.bindValue(":contentHash", currentHash);
+            backfill.bindValue(":filePath", sheet->filePath());
+            if (!backfill.exec()) {
+                qCWarning(appLog) << "Failed to backfill operation contentHash:" << backfill.lastError();
+            }
+        }
+
         // 网络文档：命中即刷新打开时间，作为 7 天超时清理的时间基准
         if (Dr::isNetworkPath(sheet->filePath())) {
             QSqlQuery touchQuery(m_database);
@@ -407,8 +465,8 @@ int Database::cleanupOrphanStates()
 {
     qCDebug(appLog) << "Starting orphan state cleanup";
     QSqlQuery query(m_database);
-    // 同时取出 lastOpened，用于网络文档的 7 天超时判断
-    if (!query.exec("SELECT filePath, lastOpened FROM operation")) {
+    // 同时取出 lastOpened、contentHash，用于保留判定与超时判断
+    if (!query.exec("SELECT filePath, lastOpened, contentHash FROM operation")) {
         qCWarning(appLog) << "Failed to query operations for cleanup:" << query.lastError();
         return 0;
     }
@@ -440,7 +498,21 @@ int Database::cleanupOrphanStates()
                 qCDebug(appLog) << "Skipping removable media path:" << filePath;
                 continue;
             }
-            orphanPaths.append(filePath);
+            // 文件可能只是被重命名/移动：带内容指纹的记录不立即删除，
+            // 保留供打开新路径时通过 matchOperationByContent 按指纹迁移
+            // （阅读进度与书签随迁移更新路径）；长期未打开则按 7 天超时清理。
+            // 无指纹的旧格式记录无法参与内容匹配，维持原立即清理策略。
+            const qint64 lastOpened = query.value("lastOpened").toLongLong();
+            const QString contentHash = query.value("contentHash").toString();
+            if (contentHash.isEmpty() || lastOpened <= 0
+                || now - lastOpened > networkTimeoutMs) {
+                qCInfo(appLog) << "Orphan document state cleanup (no fingerprint or expired):" << filePath;
+                orphanPaths.append(filePath);
+            } else {
+                qCInfo(appLog) << "Keeping missing-file state for content re-match (lastOpened"
+                                << QDateTime::fromMSecsSinceEpoch(lastOpened).toString() << "):" << filePath;
+            }
+            continue;
         }
     }
 
@@ -629,7 +701,7 @@ bool Database::prepareBookmark()
     Transaction transaction(m_database);
 
     QSqlQuery query(m_database);
-    if (!query.exec("CREATE TABLE bookmark(filePath TEXT,bookmarkIndex INTEGER)")) {
+    if (!query.exec("CREATE TABLE bookmark(filePath TEXT,bookmarkIndex INTEGER,contentHash TEXT DEFAULT '')")) {
         qCWarning(appLog) << "Failed to create bookmark table:" << query.lastError();
         return false;
     }
@@ -659,8 +731,50 @@ bool Database::readBookmarks(const QString &filePath, QSet<int> &bookmarks)
             return false;
         }
 
+        // 内容指纹校验：同名路径下换了文件（删除重命名、覆盖等）不应继承旧文件的书签。
+        // 保存书签时记录了当时文件的内容哈希，读取时与当前文件哈希比对。
+        const QString currentHash = computeContentHash(filePath);
+        const bool canVerify = !currentHash.isEmpty();
+
+        QStringList staleIndexes;   // 指纹不匹配的过期书签（属于旧文件）
+        bool hasLegacyRows = false; // 旧版本数据（无指纹）
         while (query.next()) {
-            bookmarks.insert(query.value("bookmarkIndex").toInt());
+            const int index = query.value("bookmarkIndex").toInt();
+            const QString rowHash = query.value("contentHash").toString();
+            if (canVerify && !rowHash.isEmpty() && rowHash != currentHash) {
+                qCInfo(appLog) << "Stale bookmark dropped (content mismatch):" << filePath
+                                << "page" << index;
+                staleIndexes << QString::number(index);
+                continue;
+            }
+            bookmarks.insert(index);
+            if (canVerify && rowHash.isEmpty()) {
+                hasLegacyRows = true;
+            }
+        }
+
+        // 旧版本数据（无指纹）：批量回填当前文件指纹，后续打开即可校验
+        // （放在遍历结束后执行，避免在 SELECT 迭代过程中写库）
+        if (hasLegacyRows) {
+            QSqlQuery backfill(m_database);
+            backfill.prepare("UPDATE bookmark SET contentHash = :contentHash "
+                             "WHERE filePath = :filePath AND contentHash = ''");
+            backfill.bindValue(":contentHash", currentHash);
+            backfill.bindValue(":filePath", filePath);
+            if (!backfill.exec()) {
+                qCWarning(appLog) << "Failed to backfill bookmark contentHash:" << backfill.lastError();
+            }
+        }
+
+        // 清除属于旧文件的过期书签，避免残留
+        if (!staleIndexes.isEmpty()) {
+            QSqlQuery delQuery(m_database);
+            delQuery.prepare(QString("DELETE FROM bookmark WHERE filePath = :filePath "
+                                     "AND bookmarkIndex IN (%1)").arg(staleIndexes.join(",")));
+            delQuery.bindValue(":filePath", filePath);
+            if (!delQuery.exec()) {
+                qCWarning(appLog) << "Failed to remove stale bookmarks:" << delQuery.lastError();
+            }
         }
 
         return true;
@@ -688,16 +802,20 @@ bool Database::saveBookmarks(const QString &filePath, const QSet<int> bookmarks)
             return false;
         }
 
+        // 记录当前文件内容指纹，供读取时校验书签是否属于该文件
+        const QString contentHash = computeContentHash(filePath);
+
         foreach (int index, bookmarks) {
             if (!query.prepare(" insert into "
-                               " bookmark(filePath,bookmarkIndex)"
-                               " VALUES(:filePath,:bookmarkIndex)")) {
+                               " bookmark(filePath,bookmarkIndex,contentHash)"
+                               " VALUES(:filePath,:bookmarkIndex,:contentHash)")) {
                 qCInfo(appLog) << query.lastError();
                 return false;
             }
 
             query.bindValue(":filePath", filePath);
             query.bindValue(":bookmarkIndex", index);
+            query.bindValue(":contentHash", contentHash);
 
             if (!query.exec()) {
                 qCInfo(appLog) << query.lastError().text();
@@ -756,6 +874,9 @@ Database::Database(QObject *parent) : QObject(parent)
 
         if (!tables.contains("bookmark")) {
             prepareBookmark();
+        } else {
+            // 旧书签表迁移：增加内容指纹列
+            migrateBookmarkTable();
         }
 
         if (!tables.contains("tabgroup")) {

--- a/reader/app/Database.h
+++ b/reader/app/Database.h
@@ -56,7 +56,7 @@ public:
 
     /**
      * @brief readBookmarks
-     * 读取书签
+     * 读取书签（带内容指纹校验：同名但内容不同的文件不会继承旧文件的书签）
      * @param filePath 文件名(唯一标识)
      * @param bookmarks 书签列表
      * @return
@@ -65,7 +65,7 @@ public:
 
     /**
      * @brief saveBookmarks
-     * 保存书签
+     * 保存书签（同时记录当前文件内容指纹，供读取时校验）
      * @param filePath 文件名(唯一标识)
      * @param bookmarks 书签列表
      * @return
@@ -118,6 +118,9 @@ public:
     /**
      * @brief cleanupOrphanStates
      * 清理已不存在的本地文档对应的状态记录；
+     * 带内容指纹的记录不立即删除（文件可能只是被重命名/移动，
+     * 需保留供打开新路径时按指纹迁移），改用与网络文档一致的
+     * 7 天超时策略；无指纹的旧格式记录维持原删除策略；
      * 网络文档按超时清理：超过 7 天未打开的记录（含书签）被清除
      * @return 清理的记录数
      */
@@ -172,6 +175,13 @@ private:
      * @return
      */
     bool migrateOperationTable();
+
+    /**
+     * @brief migrateBookmarkTable
+     * 迁移书签表（增加 contentHash 内容指纹列）
+     * @return
+     */
+    bool migrateBookmarkTable();
 
     QSqlDatabase m_database;
 

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -612,15 +612,26 @@ bool DocSheet::saveData()
     PERF_PRINT_BEGIN("POINT-04", QString("filename=%1,filesize=%2").arg(QFileInfo(this->filePath()).fileName()).arg(QFileInfo(this->filePath()).size()));
 
     //文档改变或者原文档被删除 则进行数据保存
-    if ((m_documentChanged || !QFile(m_filePath).exists()) && !m_renderer->save())
+    const bool fileWasMissing = !QFile(m_filePath).exists();
+    if ((m_documentChanged || fileWasMissing) && !m_renderer->save())
         return false;
 
+    // 保存（或重建文件）会导致文件内容变化
+    const bool contentSaved = m_documentChanged || fileWasMissing;
     m_documentChanged = false;
 
-    if (m_bookmarkChanged && !Database::instance()->saveBookmarks(filePath(), m_bookmarks))
+    // 书签有变化，或保存导致文件内容变化时，都重写书签以刷新内容指纹，
+    // 避免下次打开时书签因指纹不匹配被误判为旧文件遗留
+    if ((m_bookmarkChanged || contentSaved) && !Database::instance()->saveBookmarks(filePath(), m_bookmarks))
         return false;
 
     m_bookmarkChanged = false;
+
+    // 保存会改变文件内容，同步刷新缓存哈希，
+    // 避免后续自动保存将过期哈希写入 operation 导致下次打开时误判过期
+    if (contentSaved) {
+        m_cachedContentHash = Database::computeContentHash(m_filePath);
+    }
 
     m_sidebar->changeResetModelData();
 
@@ -1702,6 +1713,9 @@ void DocSheet::setAlive(bool alive)
             if (m_renderer->save()) {
                 m_documentChanged = false;
                 m_sidebar->changeResetModelData();
+                // 注释保存后文件内容已变化，重写书签刷新内容指纹，
+                // 避免下次打开时书签因指纹不匹配被误判为旧文件遗留
+                Database::instance()->saveBookmarks(filePath(), m_bookmarks);
             } else {
                 qCWarning(appLog) << "Failed to save document annotations on close for:" << m_filePath;
             }
@@ -2058,23 +2072,33 @@ void DocSheet::onAutoSave()
 {
     qCDebug(appLog) << "Auto-save triggered for:" << m_filePath;
 
-    saveProgressToDb();
-
-    // 兜底保存书签（正常情况 setBookMark 已立即落盘，此处分防其他路径设的脏标记）
-    if (m_bookmarkChanged) {
-        Database::instance()->saveBookmarks(filePath(), m_bookmarks);
-        m_bookmarkChanged = false;
-    }
-
-    // 保存文档注释（高亮、文本标注等），防止异常退出时注释丢失
+    // 先保存文档注释（高亮、文本标注等），防止异常退出时注释丢失；
+    // 保存会改变文件内容，之后的指纹/哈希计算必须基于最新内容
+    bool contentSaved = false;
     if (m_documentChanged) {
         if (m_renderer && m_renderer->save()) {
             m_documentChanged = false;
             m_sidebar->changeResetModelData();
+            contentSaved = true;
         } else {
             qCWarning(appLog) << "Auto-save: failed to save document annotations for:" << m_filePath;
         }
     }
+
+    // 兜底保存书签（正常情况 setBookMark 已立即落盘，此处分防其他路径设的脏标记）；
+    // 注释保存导致内容变化时也重写一次，刷新书签内容指纹，
+    // 避免下次打开时书签因指纹不匹配被误判为旧文件遗留
+    if (m_bookmarkChanged || contentSaved) {
+        Database::instance()->saveBookmarks(filePath(), m_bookmarks);
+        m_bookmarkChanged = false;
+    }
+
+    // 注释保存会改变文件内容，此时必须重算哈希，保证 operation 与文件实际内容一致；
+    // 其余情况沿用缓存哈希（无缓存时由 saveProgressToDb 内部计算），避免每30秒读盘计算
+    if (contentSaved) {
+        m_cachedContentHash = Database::computeContentHash(m_filePath);
+    }
+    saveProgressToDb();
 
     CentralDocPage *docPage = qobject_cast<CentralDocPage *>(parent());
     if (docPage && docPage->getCurSheet() == this) {

--- a/tests/app/ut_database.cpp
+++ b/tests/app/ut_database.cpp
@@ -10,6 +10,7 @@
 
 #include <QTest>
 #include <QSqlQuery>
+#include <QSqlError>
 #include <QDateTime>
 
 #include <gtest/gtest.h>
@@ -276,4 +277,321 @@ TEST_F(TestDatabase, UT_Database_lastOpened_001)
     // 时间戳在 1 分钟以内视为有效
     EXPECT_GT(lastOpened, now - 60 * 1000);
     EXPECT_LE(lastOpened, now);
+}
+
+TEST_F(TestDatabase, UT_Database_cleanupOrphanStates_004)
+{
+    // 文件不存在（重命名/移动场景）的清理策略：
+    // 带指纹且最近打开 → 保留待内容匹配迁移；带指纹但超 7 天 → 清理；
+    // 无指纹 → 维持原立即清理策略
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString doc = dir + "/cleanup_keep.pdf";
+    QFile::remove(doc);
+    ASSERT_TRUE(QFile::copy(src, doc));
+    const QString hash = Database::computeContentHash(doc);
+    ASSERT_FALSE(hash.isEmpty());
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    const qint64 days8 = qint64(8) * 24 * 60 * 60 * 1000;
+    // 三条记录的路径都指向不存在的文件
+    const QString ghostRecent = dir + "/ghost_recent.pdf";
+    const QString ghostExpired = dir + "/ghost_expired.pdf";
+    const QString ghostLegacy = dir + "/ghost_legacy.pdf";
+
+    QSqlQuery query(m_tester->m_database);
+    struct Ghost {
+        QString path;
+        QString hash;
+        qint64 lastOpened;
+    };
+    const QList<Ghost> ghosts = {
+        { ghostRecent, hash, now },
+        { ghostExpired, hash, now - days8 },
+        { ghostLegacy, QString(), now },
+    };
+    for (const Ghost &g : ghosts) {
+        // 幂等清理历史残留
+        query.prepare("DELETE FROM operation WHERE filePath = :p");
+        query.bindValue(":p", g.path);
+        ASSERT_TRUE(query.exec());
+        query.prepare("DELETE FROM bookmark WHERE filePath = :p");
+        query.bindValue(":p", g.path);
+        ASSERT_TRUE(query.exec());
+        // 插入 operation + bookmark 记录
+        query.prepare("INSERT INTO operation(filePath, contentHash, lastOpened) VALUES(:p, :h, :t)");
+        query.bindValue(":p", g.path);
+        query.bindValue(":h", g.hash);
+        query.bindValue(":t", g.lastOpened);
+        ASSERT_TRUE(query.exec());
+        query.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) VALUES(:p, 0, :h)");
+        query.bindValue(":p", g.path);
+        query.bindValue(":h", g.hash);
+        ASSERT_TRUE(query.exec());
+    }
+
+    m_tester->cleanupOrphanStates();
+
+    // 带指纹 + 最近打开：保留，等待打开新路径时按指纹迁移
+    EXPECT_EQ(ut_operation_count(m_tester, ghostRecent), 1);
+    EXPECT_EQ(ut_bookmark_count(m_tester, ghostRecent), 1);
+    // 带指纹但超 7 天未打开：清理
+    EXPECT_EQ(ut_operation_count(m_tester, ghostExpired), 0);
+    EXPECT_EQ(ut_bookmark_count(m_tester, ghostExpired), 0);
+    // 无指纹旧格式记录：立即清理
+    EXPECT_EQ(ut_operation_count(m_tester, ghostLegacy), 0);
+    EXPECT_EQ(ut_bookmark_count(m_tester, ghostLegacy), 0);
+
+    // 测试库持久共享：清理指向不存在文件的记录，
+    // 避免残留干扰后续用例的内容匹配（match 会选 lastOpened 最新者）
+    for (const Ghost &g : ghosts) {
+        query.prepare("DELETE FROM operation WHERE filePath = :p");
+        query.bindValue(":p", g.path);
+        ASSERT_TRUE(query.exec());
+        query.prepare("DELETE FROM bookmark WHERE filePath = :p");
+        query.bindValue(":p", g.path);
+        ASSERT_TRUE(query.exec());
+    }
+
+    QFile::remove(doc);
+}
+
+TEST_F(TestDatabase, UT_Database_renameBookmarkMigration_001)
+{
+    // 端到端：文件重命名 → 启动清理不再误删旧记录 →
+    // 打开新路径时 matchOperationByContent 迁移阅读状态与书签
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString doc1 = dir + "/rename_src.pdf";
+    const QString docMoved = dir + "/rename_dst.pdf";
+
+    // 清理历史残留
+    DocSheet sheet(Dr::FileType::PDF, doc1, nullptr);
+    m_tester->saveBookmarks(doc1, QSet<int>());
+    m_tester->saveBookmarks(docMoved, QSet<int>());
+
+    ASSERT_TRUE(QFile::copy(src, doc1));
+
+    // 文档加书签并保存阅读状态（saveOperation 同时写入指纹）
+    ASSERT_TRUE(m_tester->saveBookmarks(doc1, QSet<int> {0}));
+    sheet.m_operation.currentPage = 5;
+    ASSERT_TRUE(m_tester->saveOperation(&sheet, Database::computeContentHash(doc1)));
+
+    // 用户重命名文件（内容不变）
+    ASSERT_TRUE(QFile::rename(doc1, docMoved));
+
+    // 模拟下次启动的孤立记录清理：旧路径记录应保留（带指纹、最近打开）
+    m_tester->cleanupOrphanStates();
+    EXPECT_EQ(ut_operation_count(m_tester, doc1), 1);
+    EXPECT_EQ(ut_bookmark_count(m_tester, doc1), 1);
+
+    // 打开新路径：内容匹配迁移，书签与阅读状态都跟随
+    EXPECT_TRUE(m_tester->matchOperationByContent(QFileInfo(docMoved), &sheet));
+    EXPECT_EQ(ut_operation_count(m_tester, doc1), 0);
+    EXPECT_EQ(ut_bookmark_count(m_tester, doc1), 0);
+
+    QSet<int> bookmarks;
+    EXPECT_TRUE(m_tester->readBookmarks(docMoved, bookmarks));
+    EXPECT_EQ(bookmarks, QSet<int> {0});
+
+    // 清理迁移后的记录
+    m_tester->saveBookmarks(docMoved, QSet<int>());
+    QSqlQuery clean(m_tester->m_database);
+    clean.prepare("DELETE FROM operation WHERE filePath = :p");
+    clean.bindValue(":p", docMoved);
+    ASSERT_TRUE(clean.exec());
+
+    QFile::remove(docMoved);
+}
+
+// ===== 书签内容指纹校验 =====
+
+// 准备临时目录及两个内容不同的真实文件（computeContentHash 需要读取文件）
+static QString ut_bookmark_prepare_files(QString &doc1, QString &doc2)
+{
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    doc1 = dir + "/doc.pdf";
+    doc2 = dir + "/doc2.pdf";
+    QFile::remove(doc1);
+    QFile::remove(doc2);
+    EXPECT_TRUE(QFile::copy(src, doc1));
+    EXPECT_TRUE(QFile::copy(src, doc2));
+    // 追加数据使 doc2 与 doc1 内容不同
+    QFile f2(doc2);
+    EXPECT_TRUE(f2.open(QIODevice::Append));
+    f2.write(QByteArray(4096, 'x'));
+    f2.close();
+    return dir;
+}
+
+TEST_F(TestDatabase, UT_Database_bookmarkContentHash_001)
+{
+    // 同名不同内容的文件不应继承旧文件的书签
+    // （bug场景：文档1加书签后删除，文档2改名为文档1，文档2不应显示书签）
+    QString doc1, doc2;
+    ut_bookmark_prepare_files(doc1, doc2);
+    ASSERT_NE(Database::computeContentHash(doc1), Database::computeContentHash(doc2));
+
+    // 文档1 第 1 页添加书签，正常读取
+    ASSERT_TRUE(m_tester->saveBookmarks(doc1, QSet<int> {0}));
+    QSet<int> read;
+    EXPECT_TRUE(m_tester->readBookmarks(doc1, read));
+    EXPECT_EQ(read, QSet<int> {0});
+
+    // 文档1 被删除，文档2 改名为文档1（同路径、不同内容）
+    QFile::remove(doc1);
+    ASSERT_TRUE(QFile::rename(doc2, doc1));
+
+    // 旧文件的书签不应出现在新文件上，且过期记录已被清除
+    read.clear();
+    EXPECT_TRUE(m_tester->readBookmarks(doc1, read));
+    EXPECT_TRUE(read.isEmpty());
+    EXPECT_EQ(ut_bookmark_count(m_tester, doc1), 0);
+
+    QFile::remove(doc1);
+}
+
+TEST_F(TestDatabase, UT_Database_readOperationContentHash_001)
+{
+    // 同名不同内容的文件不应继承旧文档的阅读状态（与书签同根因）
+    QString doc1, doc2;
+    ut_bookmark_prepare_files(doc1, doc2);
+
+    // 文档1 正常阅读并保存状态（此时文件内容为 H1）
+    {
+        DocSheet sheet1(Dr::FileType::PDF, doc1, nullptr);
+        sheet1.m_operation.currentPage = 42;
+        ASSERT_TRUE(m_tester->saveOperation(&sheet1));
+    }
+    // 注意：sheet1 析构（setAlive(false)）会再次 saveOperation，记录内容不变
+
+    // 文档1 被删除，文档2 改名为文档1（同路径、不同内容）
+    QFile::remove(doc1);
+    ASSERT_TRUE(QFile::rename(doc2, doc1));
+
+    // 打开新文件：过期状态不应被恢复，且过期记录已被清除
+    // （DocSheet 构造即 setAlive(true)，此处 readOperation 已被调用过一次并删除过期记录）
+    {
+        DocSheet sheet2(Dr::FileType::PDF, doc1, nullptr);
+        EXPECT_FALSE(m_tester->readOperation(&sheet2));
+        // currentPage 保持默认值 1，未被旧文档状态（42）污染
+        EXPECT_EQ(sheet2.m_operation.currentPage, 1);
+        EXPECT_EQ(ut_operation_count(m_tester, doc1), 0);
+    }
+
+    QFile::remove(doc1);
+}
+
+TEST_F(TestDatabase, UT_Database_readOperationContentHash_002)
+{
+    // 同一文件状态正常恢复；旧版本记录（无指纹）读取时回填
+    // （使用独立路径，避免其它用例 DocSheet 析构时 saveOperation 写入的记录干扰）
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString doc = dir + "/legacy_op.pdf";
+    QFile::remove(doc);
+    ASSERT_TRUE(QFile::copy(src, doc));
+
+    // 幂等清理：DocSheet 析构（setAlive(false)）会 saveOperation 写回记录，
+    // 测试数据库持久化，需先清除历史残留避免主键冲突
+    QSqlQuery clean(m_tester->m_database);
+    clean.prepare("DELETE FROM operation WHERE filePath = :p");
+    clean.bindValue(":p", doc);
+    ASSERT_TRUE(clean.exec());
+    qWarning() << "DELETE affected:" << clean.numRowsAffected();
+
+    // 直接插入一条无指纹的旧格式记录（exec 仅执行一次，重复执行会撞主键）
+    QSqlQuery insert(m_tester->m_database);
+    insert.prepare("INSERT INTO operation(filePath, currentPage, contentHash) VALUES(:p, 7, '')");
+    insert.bindValue(":p", doc);
+    const bool inserted = insert.exec();
+    if (!inserted) {
+        qWarning() << "INSERT failed:" << insert.lastError().text();
+    }
+    ASSERT_TRUE(inserted);
+
+    {
+        DocSheet sheet(Dr::FileType::PDF, doc, nullptr);
+        EXPECT_TRUE(m_tester->readOperation(&sheet));
+        EXPECT_EQ(sheet.m_operation.currentPage, 7);
+
+        // 指纹已回填，再次读取仍能恢复
+        QSqlQuery query(m_tester->m_database);
+        query.prepare("SELECT contentHash FROM operation WHERE filePath = :p");
+        query.bindValue(":p", doc);
+        ASSERT_TRUE(query.exec());
+        ASSERT_TRUE(query.next());
+        EXPECT_EQ(query.value(0).toString(), Database::computeContentHash(doc));
+
+        EXPECT_TRUE(m_tester->readOperation(&sheet));
+        EXPECT_EQ(sheet.m_operation.currentPage, 7);
+    }
+    // sheet 已析构，清理其写回的记录
+    ASSERT_TRUE(clean.exec());
+
+    QFile::remove(doc);
+}
+
+TEST_F(TestDatabase, UT_Database_bookmarkContentHash_002)
+{
+    // 同一文件书签读写不受影响；旧版本数据（无指纹）读取时回填
+    QString doc1, doc2;
+    ut_bookmark_prepare_files(doc1, doc2);
+    QFile::remove(doc2);
+
+    // 直接插入一条无指纹的旧格式记录
+    QSqlQuery insert(m_tester->m_database);
+    insert.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) VALUES(:p, :i, '')");
+    insert.bindValue(":p", doc1);
+    insert.bindValue(":i", 3);
+    ASSERT_TRUE(insert.exec());
+
+    // 读取时旧书签保留且指纹被回填
+    QSet<int> read;
+    EXPECT_TRUE(m_tester->readBookmarks(doc1, read));
+    EXPECT_EQ(read, QSet<int> {3});
+
+    QSqlQuery query(m_tester->m_database);
+    query.prepare("SELECT contentHash FROM bookmark WHERE filePath = :p");
+    query.bindValue(":p", doc1);
+    ASSERT_TRUE(query.exec());
+    ASSERT_TRUE(query.next());
+    EXPECT_EQ(query.value(0).toString(), Database::computeContentHash(doc1));
+
+    // 同一文件再次读取，书签仍正常
+    read.clear();
+    EXPECT_TRUE(m_tester->readBookmarks(doc1, read));
+    EXPECT_EQ(read, QSet<int> {3});
+
+    QFile::remove(doc1);
+}
+
+TEST_F(TestDatabase, UT_Database_bookmarkContentHash_003)
+{
+    // 文件不可读（无法计算指纹）时跳过校验，按旧行为返回书签且不删除记录
+    QString doc1, doc2;
+    ut_bookmark_prepare_files(doc1, doc2);
+    QFile::remove(doc2);
+
+    ASSERT_TRUE(m_tester->saveBookmarks(doc1, QSet<int> {2}));
+
+    // 移除读权限，使 computeContentHash 失败（root 下仍可读，不走该分支，但用例仍应通过）
+    QFile::setPermissions(doc1, QFile::Permissions());
+
+    QSet<int> read;
+    EXPECT_TRUE(m_tester->readBookmarks(doc1, read));
+    EXPECT_EQ(read, QSet<int> {2});
+    EXPECT_EQ(ut_bookmark_count(m_tester, doc1), 1);
+
+    QFile::setPermissions(doc1, QFile::ReadOwner | QFile::WriteOwner);
+    QFile::remove(doc1);
 }


### PR DESCRIPTION
Validate the file content fingerprint (SHA256) when saving and reading bookmarks and reading-state records, so a different document with the same file path no longer inherits the previous document's bookmarks or reading position. Legacy records without fingerprint are backfilled on read; stale records are dropped when content no longer matches.

startup cleanupOrphanStates() deleted records whose local file no longer exists, wiping renamed/moved files' bookmarks before the content re-match could happen. Keep records that carry a fingerprint and were opened recently (cleaned after the 7-day timeout, same as network docs); opening the renamed file re-matches by fingerprint and migrates both reading state and bookmarks. Legacy records without fingerprint keep the original immediate-cleanup policy.

书签与阅读状态记录增加内容指纹校验，同名不同内容的文档不再继承
旧文档的书签和阅读进度；旧格式数据读取时自动回填指纹，指纹不
匹配的过期记录自动清除。

启动清理不再立即删除"文件不存在"的带指纹记录（保留至 7 天超时，
与网络文档策略一致）：文件重命名/移动后打开新路径时按指纹重新
匹配，阅读状态与书签一并迁移；无指纹旧记录维持原清理策略。

Log: 书签和阅读状态增加内容指纹校验，重命名后书签可随内容迁移
PMS: BUG-376031
Influence: 修复删除文档1后同名文档2错误显示文档1书签、以及文件重命
名/移动后书签丢失的问题；bookmark 表自动迁移新增 contentHash 列，旧
版本书签数据兼容回填不丢失；启动清理对带指纹且最近打开的缺失文件
记录保留 7 天待迁移。

## Summary by Sourcery

Protect document bookmarks and reading state with content fingerprint validation while preserving migration across file renames and moves.

Bug Fixes:
- Prevent bookmarks and reading state from being inherited by different documents that reuse the same file path by validating content fingerprints.
- Preserve recently opened fingerprinted records long enough to migrate bookmarks and reading state after files are renamed or moved.

Enhancements:
- Backfill content fingerprints for legacy bookmark and reading-state records when they are read.
- Remove stale records whose fingerprints no longer match the current document content.
- Add bookmark-table migration support for the new content fingerprint column.

Tests:
- Add coverage for orphan-record retention and expiry, renamed-file migration, content mismatches, legacy fingerprint backfilling, and unreadable files.