### PR TITLE
chore: Update version to 6.5.62

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+deepin-reader (6.5.62) unstable; urgency=medium
+
+  * chore: Update version to 6.5.62
+  * fix(database): verify content hash before restoring bookmarks and state
+  * fix: save reading progress along with bookmark operations
+  * fix(database): clear expired network document state after 7 days
+  * fix: prevent background sheet changes broadcasting sigCurSheetChanged
+  * fix: prevent restore tip reappearing after tab switch on close
+  * fix(uiframe): save annotation immediately after operation
+  * [skip CI] Translate deepin-reader.ts in ar
+  * [skip CI] Translate deepin-reader.ts in sv
+  * [skip CI] Translate desktop.ts in sv
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Fri, 04 Sep 2026 15:09:32 +0800
+
 deepin-reader (6.5.61) unstable; urgency=medium
 
   * chore: Update version to 6.5.61

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.61.1
+  version: 6.5.62.1
   kind: app
   description: |
     reader for deepin os.


### PR DESCRIPTION
- update version to 6.5.62

log: update version to 6.5.62

## Summary by Sourcery

Build:
- Update the package version to 6.5.62.1 and record the corresponding release in the Debian changelog.