### PR TITLE
chore: Update version to 6.5.63

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-reader (6.5.63) unstable; urgency=medium
+
+  * chore: Update version to 6.5.63
+  * fix(database): verify content hash before restoring bookmarks and state
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Fri, 04 Sep 2026 15:51:48 +0800
+
 deepin-reader (6.5.62) unstable; urgency=medium
 
   * chore: Update version to 6.5.62

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.reader
   name: "deepin-reader"
-  version: 6.5.62.1
+  version: 6.5.63.1
   kind: app
   description: |
     reader for deepin os.


### PR DESCRIPTION
- update version to 6.5.63

log: update version to 6.5.63

## Summary by Sourcery

Chores:
- Update the Debian package changelog and application package metadata to version 6.5.63.