### PR TITLE
fix(reader): construct QSet with explicit insert loop for Qt5/Qt6 com…

### DIFF
--- a/reader/main.cpp
+++ b/reader/main.cpp
@@ -140,7 +140,9 @@ int main(int argc, char *argv[])
             // 合并文件列表：保留历史标签页及其拖拽后的顺序，仅追加新打开的文件
             // 这样重新打开相同文件时能保持上次的标签顺序；打开新文件时历史不会丢失
             QStringList allFiles = validRestored;
-            QSet<QString> restoredSet(validRestored.begin(), validRestored.end());
+            QSet<QString> restoredSet;
+            for (const QString &path : validRestored)
+                restoredSet.insert(path);
             int newFileCount = 0;
             for (const QString &fp : localArguments) {
                 if (QFile::exists(fp) && !restoredSet.contains(fp)) {


### PR DESCRIPTION
…patibility

The iterator-range constructor QSet(begin, end) was introduced in Qt 5.14, causing a build failure on Qt 5.11.3. Using QSet::fromList() instead would break Qt6 builds since it was removed in Qt6. Replace with an explicit insert loop, which compiles on all supported Qt versions (5.11.3, 5.14+, and 6.x).

Log: 修复QSet构造方式在Qt5.11.3和Qt6上的编译兼容性问题
Bug: 本地编译时发现的问题，并无 bug 链接
Influence: 解决reader模块在Qt5.11.3下编译报错，同时保持Qt6兼容

## Summary by Sourcery

Bug Fixes:
- Restore reader builds across supported Qt 5.11.3, Qt 5.14+, and Qt 6 versions by using a Qt-compatible QSet construction approach.