### PR TITLE
fix(reader): merge duplicate content records to restore bookmarks

### DIFF
--- a/reader/app/Database.cpp
+++ b/reader/app/Database.cpp
@@ -25,9 +25,35 @@
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonValue>
+#include <QMultiMap>
 
 // 网络文档阅读状态的保留时长：超过该天数未打开则视为过期，启动时清理
 static constexpr int kNetworkStateTimeoutDays = 7;
+
+/**
+ * @brief isRemovableOrNetworkPath
+ * 判断路径是否位于可移动设备或网络位置。此类路径未挂载/断开时
+ * QFile::exists() 恒为 false，但文件实际仍在设备/服务器上，
+ * 存在性判断不可靠，涉及记录合并/迁移时须保守处理
+ */
+static bool isRemovableOrNetworkPath(const QString &filePath)
+{
+    return Dr::isNetworkPath(filePath)
+        || filePath.startsWith("/media/")
+        || filePath.startsWith("/mnt/")
+        || filePath.startsWith("/run/media/");
+}
+
+/**
+ * @brief isPathProvablyGone
+ * 判断路径上的文件是否确定已不存在（文件被移动/重命名的特征）。
+ * 只有可靠的本地路径经 QFile::exists() 确认不存在才返回 true；
+ * 可移动设备/网络路径因存在性不可靠，一律视为文件仍在
+ */
+static bool isPathProvablyGone(const QString &filePath)
+{
+    return !isRemovableOrNetworkPath(filePath) && !QFile::exists(filePath);
+}
 
 Transaction::Transaction(QSqlDatabase &database)
     : m_committed(false), m_database(database)
@@ -261,6 +287,10 @@ bool Database::readOperation(DocSheet *sheet)
             }
         }
 
+        // 同内容其他路径记录合并（仅限源文件已不存在的移动/重命名残留，
+        // 见 mergeDuplicateRecords；源文件仍存在的记录保持独立，不参与合并）
+        mergeDuplicateRecords(sheet);
+
         // 网络文档：命中即刷新打开时间，作为 7 天超时清理的时间基准
         if (Dr::isNetworkPath(sheet->filePath())) {
             QSqlQuery touchQuery(m_database);
@@ -351,28 +381,44 @@ bool Database::matchOperationByContent(const QFileInfo &fileInfo, DocSheet *shee
 
     Transaction matchTransaction(m_database);
 
+    // 迁移池：源文件已确认消失（可靠的本地路径经存在性确认）→ 移动/重命名，记录整体迁移
     QVariantMap bestRow;
+    // 借用池：源文件仍存在 → 复制到U盘等副本场景，仅首开借用状态，不动源记录
+    QVariantMap borrowRow;
+    auto rowToMap = [](const QSqlQuery &query) {
+        QVariantMap row;
+        for (int i = 0; i < query.record().count(); ++i)
+            row.insert(query.record().fieldName(i), query.value(i));
+        return row;
+    };
 
     // 优先通过 docId 匹配（PDF /ID，改名/移动不变，最可靠）
     if (!docId.isEmpty()) {
         QSqlQuery idQuery(m_database);
-        idQuery.prepare("SELECT * FROM operation WHERE docId = :docId AND docId != ''");
+        // 排除目标路径自身的记录：同一份文件可能在目标路径已有旧记录，
+        // 选中它会导致 oldPath == newPath，做一次无效迁移
+        idQuery.prepare("SELECT * FROM operation WHERE docId = :docId AND docId != '' AND filePath != :filePath");
         idQuery.bindValue(":docId", docId);
-        if (idQuery.exec() && idQuery.next()) {
-            for (int i = 0; i < idQuery.record().count(); ++i)
-                bestRow.insert(idQuery.record().fieldName(i), idQuery.value(i));
-            qint64 bestModTime = bestRow.value("lastModified").toLongLong();
-            // docId 相同时选最近修改的记录
+        idQuery.bindValue(":filePath", fileInfo.absoluteFilePath());
+        if (idQuery.exec()) {
+            // docId 相同时选最近修改的记录。
+            // 源文件已消失的进入迁移池；仍存在的进入借用池：
+            // 同一份内容在多个路径共存时不得夺走源路径的记录，
+            // 但新路径首次打开（自身无记录）可借用一份源状态
             while (idQuery.next()) {
-                qint64 modTime = idQuery.value("lastModified").toLongLong();
-                if (modTime > bestModTime) {
-                    bestModTime = modTime;
-                    bestRow.clear();
-                    for (int i = 0; i < idQuery.record().count(); ++i)
-                        bestRow.insert(idQuery.record().fieldName(i), idQuery.value(i));
+                const QVariantMap row = rowToMap(idQuery);
+                const qint64 modTime = row.value("lastModified").toLongLong();
+                if (!isPathProvablyGone(row.value("filePath").toString())) {
+                    if (borrowRow.isEmpty() || modTime > borrowRow.value("lastModified").toLongLong())
+                        borrowRow = row;
+                    continue;
                 }
+                if (bestRow.isEmpty() || modTime > bestRow.value("lastModified").toLongLong())
+                    bestRow = row;
             }
-            qCInfo(appLog) << "Matched by docId:" << docId.left(16) << "...";
+            if (!bestRow.isEmpty()) {
+                qCInfo(appLog) << "Matched by docId:" << docId.left(16) << "...";
+            }
         }
     }
 
@@ -380,62 +426,110 @@ bool Database::matchOperationByContent(const QFileInfo &fileInfo, DocSheet *shee
     if (bestRow.isEmpty()) {
         QSqlQuery query(m_database);
         // 不使用 lastModified：保存注释会修改文件 mtime，导致移动文件后匹配失败
+        // 排除目标路径自身记录，理由同 docId 分支
         query.prepare("SELECT * FROM operation WHERE fileSize = :fileSize "
-                      "AND contentHash = :contentHash");
+                      "AND contentHash = :contentHash AND filePath != :filePath");
         query.bindValue(":fileSize", fileSize);
         query.bindValue(":contentHash", contentHash);
+        query.bindValue(":filePath", fileInfo.absoluteFilePath());
 
         if (!query.exec()) {
             qCWarning(appLog) << "Content match query failed:" << query.lastError();
             return false;
         }
 
-        if (query.next()) {
-            for (int i = 0; i < query.record().count(); ++i)
-                bestRow.insert(query.record().fieldName(i), query.value(i));
-            qint64 bestModTime = bestRow.value("lastModified").toLongLong();
-
-            // 如果匹配到多条记录，选择最后修改时间最近的一条
-            while (query.next()) {
-                qint64 modTime = query.value("lastModified").toLongLong();
-                if (modTime > bestModTime) {
-                    bestModTime = modTime;
-                    bestRow.clear();
-                    for (int i = 0; i < query.record().count(); ++i)
-                        bestRow.insert(query.record().fieldName(i), query.value(i));
-                }
+        // 匹配到多条记录时选最后修改时间最近的一条；
+        // 源文件已消失的进入迁移池，仍存在的进入借用池（理由同 docId 分支）
+        while (query.next()) {
+            const QVariantMap row = rowToMap(query);
+            const qint64 modTime = row.value("lastModified").toLongLong();
+            if (!isPathProvablyGone(row.value("filePath").toString())) {
+                if (borrowRow.isEmpty() || modTime > borrowRow.value("lastModified").toLongLong())
+                    borrowRow = row;
+                continue;
             }
+            if (bestRow.isEmpty() || modTime > bestRow.value("lastModified").toLongLong())
+                bestRow = row;
         }
     }
 
-    if (bestRow.isEmpty()) {
+    if (bestRow.isEmpty() && borrowRow.isEmpty()) {
         qCDebug(appLog) << "No content match found";
         return false;
     }
 
-    // 匹配成功，读取状态并更新文件路径
-    QString oldFilePath = bestRow.value("filePath").toString();
-    qCInfo(appLog) << "Content match found: old path=" << oldFilePath << "-> new path=" << fileInfo.absoluteFilePath();
+    // 迁移优先于借用：存在源文件已消失的候选时整体迁移（移动/重命名场景）
+    const QVariantMap row = bestRow.isEmpty() ? borrowRow : bestRow;
+    const bool borrowOnly = bestRow.isEmpty();
 
-    sheet->m_operation.layoutMode = static_cast<Dr::LayoutMode>(bestRow.value("layoutMode").toInt());
-    sheet->m_operation.mouseShape = static_cast<Dr::MouseShape>(bestRow.value("mouseShape").toInt());
-    sheet->m_operation.scaleMode = static_cast<Dr::ScaleMode>(bestRow.value("scaleMode").toInt());
-    sheet->m_operation.rotation = static_cast<Dr::Rotation>(bestRow.value("rotation").toInt());
-    sheet->m_operation.scaleFactor = qBound(0.1, bestRow.value("scaleFactor").toDouble(), 5.0);
-    sheet->m_operation.sidebarVisible = bestRow.value("sidebarVisible").toInt();
-    sheet->m_operation.sidebarIndex = bestRow.value("sidebarIndex").toInt();
-    sheet->m_operation.currentPage = bestRow.value("currentPage").toInt();
-    sheet->m_operation.sidebarWidth = bestRow.value("sidebarWidth").toInt();
-    sheet->m_operation.sidebarWidthChanged = bestRow.value("sidebarWidthChanged").toInt() != 0;
-    sheet->m_operation.scrollPosition = bestRow.value("scrollPosition").toFloat();
+    QString oldFilePath = row.value("filePath").toString();
+    qCInfo(appLog) << (borrowOnly ? "First open of a copy, borrowing state from source: "
+                                  : "Content match found: old path=")
+                   << oldFilePath << "-> new path=" << fileInfo.absoluteFilePath();
+
+    sheet->m_operation.layoutMode = static_cast<Dr::LayoutMode>(row.value("layoutMode").toInt());
+    sheet->m_operation.mouseShape = static_cast<Dr::MouseShape>(row.value("mouseShape").toInt());
+    sheet->m_operation.scaleMode = static_cast<Dr::ScaleMode>(row.value("scaleMode").toInt());
+    sheet->m_operation.rotation = static_cast<Dr::Rotation>(row.value("rotation").toInt());
+    sheet->m_operation.scaleFactor = qBound(0.1, row.value("scaleFactor").toDouble(), 5.0);
+    sheet->m_operation.sidebarVisible = row.value("sidebarVisible").toInt();
+    sheet->m_operation.sidebarIndex = row.value("sidebarIndex").toInt();
+    sheet->m_operation.currentPage = row.value("currentPage").toInt();
+    sheet->m_operation.sidebarWidth = row.value("sidebarWidth").toInt();
+    sheet->m_operation.sidebarWidthChanged = row.value("sidebarWidthChanged").toInt() != 0;
+    sheet->m_operation.scrollPosition = row.value("scrollPosition").toFloat();
     // 目录树展开状态
-    QString expandedJson = bestRow.value("expandedSections").toString();
+    QString expandedJson = row.value("expandedSections").toString();
     QJsonDocument expDoc = QJsonDocument::fromJson(expandedJson.toUtf8());
     if (expDoc.isArray()) {
         QJsonArray arr = expDoc.array();
         for (const QJsonValue &val : arr) {
             sheet->m_operation.expandedSections.append(val.toString());
         }
+    }
+
+    // 首开借用（源文件仍存在）：不迁移、不删除源路径的任何记录。
+    // 仅把匹配指纹的书签复制一份到新路径（源路径书签行原样保留），
+    // 保证 setAlive 后续 readBookmarks 能直接读到；关闭时
+    // saveOperation/saveBookmarks 照常落盘新路径自己的记录，
+    // 此后两份文档各自独立，"借用"仅发生在首开这一次
+    if (borrowOnly) {
+        QSqlQuery clearBm(m_database);
+        clearBm.prepare("DELETE FROM bookmark WHERE filePath = :newPath "
+                        "AND (contentHash = :contentHash OR contentHash = '')");
+        clearBm.bindValue(":newPath", fileInfo.absoluteFilePath());
+        clearBm.bindValue(":contentHash", row.value("contentHash").toString());
+        if (!clearBm.exec()) {
+            qCWarning(appLog) << "Failed to clear stale target bookmarks before borrowing:"
+                              << clearBm.lastError();
+        }
+        QSqlQuery copyBm(m_database);
+        // 同名占位符在 Qt SQLite 驱动下仅绑定首个出现位置，需拆名绑定
+        copyBm.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) "
+                       "SELECT :newPath, bookmarkIndex, contentHash FROM bookmark "
+                       "WHERE filePath = :oldPath "
+                       "AND (contentHash = :contentHash0 OR contentHash = :contentHash1)");
+        copyBm.bindValue(":newPath", fileInfo.absoluteFilePath());
+        copyBm.bindValue(":oldPath", oldFilePath);
+        copyBm.bindValue(":contentHash0", row.value("contentHash").toString());
+        copyBm.bindValue(":contentHash1", row.value("contentHash").toString());
+        if (!copyBm.exec()) {
+            qCWarning(appLog) << "Failed to copy bookmarks while borrowing state:"
+                              << copyBm.lastError();
+        }
+        matchTransaction.commit();
+        return true;
+    }
+
+    // 目标路径若残留旧 operation 记录（同名文档历史记录），先删除避让主键，
+    // 否则下方 UPDATE 会因 operation.filePath 主键冲突而失败
+    // （readOperation miss 已删除过期记录，此处为防御性清理，不影响未过期数据）
+    QSqlQuery clearQuery(m_database);
+    clearQuery.prepare("DELETE FROM operation WHERE filePath = :newPath AND filePath != :oldPath");
+    clearQuery.bindValue(":newPath", fileInfo.absoluteFilePath());
+    clearQuery.bindValue(":oldPath", oldFilePath);
+    if (!clearQuery.exec()) {
+        qCWarning(appLog) << "Failed to clear stale record before path update:" << clearQuery.lastError();
     }
 
     // 更新文件路径为新路径（在同一事务中保证原子性）
@@ -448,16 +542,185 @@ bool Database::matchOperationByContent(const QFileInfo &fileInfo, DocSheet *shee
         qCWarning(appLog) << "Failed to update file path after content match:" << updateQuery.lastError();
     }
 
-    // 同时更新 bookmark 表的文件路径，确保书签数据也能跟随文件迁移
-    QSqlQuery bookmarkUpdate(m_database);
-    bookmarkUpdate.prepare("UPDATE bookmark SET filePath = :newPath WHERE filePath = :oldPath");
-    bookmarkUpdate.bindValue(":newPath", fileInfo.absoluteFilePath());
-    bookmarkUpdate.bindValue(":oldPath", oldFilePath);
-    if (!bookmarkUpdate.exec()) {
-        qCWarning(appLog) << "Failed to update bookmark path after content match:" << bookmarkUpdate.lastError();
+    // 书签以「路径 + 内容指纹」为关联键，跨路径不会自动共享：
+    // 源路径文件已不存在（判定为移动/重命名），旧路径书签一并迁移到新路径
+    QSqlQuery bookmarkQuery(m_database);
+    bookmarkQuery.prepare("UPDATE bookmark SET filePath = :newPath "
+                          "WHERE filePath = :oldPath "
+                          "AND (contentHash = :contentHash OR contentHash = '')");
+    bookmarkQuery.bindValue(":newPath", fileInfo.absoluteFilePath());
+    bookmarkQuery.bindValue(":oldPath", oldFilePath);
+    bookmarkQuery.bindValue(":contentHash", bestRow.value("contentHash").toString());
+    if (!bookmarkQuery.exec()) {
+        qCWarning(appLog) << "Failed to migrate bookmarks after content match:" << bookmarkQuery.lastError();
     }
 
     matchTransaction.commit();
+    return true;
+}
+
+bool Database::mergeDuplicateRecords(DocSheet *sheet)
+{
+    if (!sheet) {
+        return false;
+    }
+
+    const QString newPath = sheet->filePath();
+
+    // 读取当前记录的内容特征（指纹已在 readOperation 中校验通过）
+    QSqlQuery curQuery(m_database);
+    curQuery.prepare("SELECT fileSize, contentHash, docId, lastOpened FROM operation WHERE filePath = :filePath");
+    curQuery.bindValue(":filePath", newPath);
+    if (!curQuery.exec() || !curQuery.next()) {
+        return false;
+    }
+    const qint64 fileSize = curQuery.value("fileSize").toLongLong();
+    const QString contentHash = curQuery.value("contentHash").toString();
+    const QString docId = curQuery.value("docId").toString();
+    qint64 curLastOpened = curQuery.value("lastOpened").toLongLong();
+
+    // 无指纹无法可靠判定同内容，不做合并
+    if (contentHash.isEmpty()) {
+        return false;
+    }
+
+    // 查找同内容的其他路径记录：docId 相同（非空）或 fileSize+指纹相同
+    QSqlQuery dupQuery(m_database);
+    dupQuery.prepare("SELECT * FROM operation WHERE filePath != :newPath AND "
+                     "((docId != '' AND docId = :docId) OR "
+                     "(fileSize = :fileSize AND contentHash = :contentHash))");
+    dupQuery.bindValue(":newPath", newPath);
+    dupQuery.bindValue(":docId", docId);
+    dupQuery.bindValue(":fileSize", fileSize);
+    dupQuery.bindValue(":contentHash", contentHash);
+    if (!dupQuery.exec()) {
+        qCWarning(appLog) << "Failed to query duplicate content records:" << dupQuery.lastError();
+        return false;
+    }
+
+    QVariantList dupRows;
+    while (dupQuery.next()) {
+        QVariantMap row;
+        for (int i = 0; i < dupQuery.record().count(); ++i) {
+            row.insert(dupQuery.record().fieldName(i), dupQuery.value(i));
+        }
+        dupRows.append(row);
+    }
+
+    if (dupRows.isEmpty()) {
+        return false;
+    }
+
+    // 当前路径书签与同内容记录独立（书签以 路径+指纹 为关联键），
+    // 源文件已不存在的旧路径书签需并入当前路径，阅读状态按 lastOpened 择优
+
+    qCInfo(appLog) << "Merging duplicate content records into:" << newPath << "count=" << dupRows.count();
+
+    Transaction mergeTransaction(m_database);
+
+    bool mergedAny = false;
+    for (const QVariant &rowVar : dupRows) {
+        const QVariantMap dup = rowVar.toMap();
+        const QString oldPath = dup.value("filePath").toString();
+        if (oldPath == newPath) {
+            continue;
+        }
+
+        // 源文件仍存在（或路径存在性不可靠）说明不是移动/重命名场景，
+        // 而是同一份内容在多个路径共存：各路径保持独立阅读状态，不合并、不删除
+        if (!isPathProvablyGone(oldPath)) {
+            qCInfo(appLog) << "Keep independent state, source file still present:" << oldPath;
+            continue;
+        }
+
+        // 阅读状态择优：取 lastOpened 较新者（书签已随内容指纹共享，无需并入）
+        const qint64 dupLastOpened = dup.value("lastOpened").toLongLong();
+        const bool dupPreferred = dupLastOpened > curLastOpened;
+
+        if (dupPreferred) {
+            QSqlQuery updQuery(m_database);
+            updQuery.prepare("UPDATE operation SET layoutMode = :layoutMode, mouseShape = :mouseShape, "
+                             "scaleMode = :scaleMode, rotation = :rotation, scaleFactor = :scaleFactor, "
+                             "sidebarVisible = :sidebarVisible, sidebarIndex = :sidebarIndex, "
+                             "currentPage = :currentPage, sidebarWidth = :sidebarWidth, "
+                             "sidebarWidthChanged = :sidebarWidthChanged, scrollPosition = :scrollPosition, "
+                             "expandedSections = :expandedSections, lastModified = :lastModified, "
+                             "lastOpened = :lastOpened WHERE filePath = :newPath");
+            updQuery.bindValue(":layoutMode", dup.value("layoutMode"));
+            updQuery.bindValue(":mouseShape", dup.value("mouseShape"));
+            updQuery.bindValue(":scaleMode", dup.value("scaleMode"));
+            updQuery.bindValue(":rotation", dup.value("rotation"));
+            updQuery.bindValue(":scaleFactor", dup.value("scaleFactor"));
+            updQuery.bindValue(":sidebarVisible", dup.value("sidebarVisible"));
+            updQuery.bindValue(":sidebarIndex", dup.value("sidebarIndex"));
+            updQuery.bindValue(":currentPage", dup.value("currentPage"));
+            updQuery.bindValue(":sidebarWidth", dup.value("sidebarWidth"));
+            updQuery.bindValue(":sidebarWidthChanged", dup.value("sidebarWidthChanged"));
+            updQuery.bindValue(":scrollPosition", dup.value("scrollPosition"));
+            updQuery.bindValue(":expandedSections", dup.value("expandedSections"));
+            updQuery.bindValue(":lastModified", dup.value("lastModified"));
+            updQuery.bindValue(":lastOpened", dup.value("lastOpened"));
+            updQuery.bindValue(":newPath", newPath);
+            if (updQuery.exec()) {
+                // 同步到内存对象，本次会话直接使用合并后的状态
+                sheet->m_operation.layoutMode = static_cast<Dr::LayoutMode>(dup.value("layoutMode").toInt());
+                sheet->m_operation.mouseShape = static_cast<Dr::MouseShape>(dup.value("mouseShape").toInt());
+                sheet->m_operation.scaleMode = static_cast<Dr::ScaleMode>(dup.value("scaleMode").toInt());
+                sheet->m_operation.rotation = static_cast<Dr::Rotation>(dup.value("rotation").toInt());
+                sheet->m_operation.scaleFactor = qBound(0.1, dup.value("scaleFactor").toDouble(), 5.0);
+                sheet->m_operation.sidebarVisible = dup.value("sidebarVisible").toInt();
+                sheet->m_operation.sidebarIndex = dup.value("sidebarIndex").toInt();
+                sheet->m_operation.currentPage = dup.value("currentPage").toInt();
+                sheet->m_operation.sidebarWidth = dup.value("sidebarWidth").toInt();
+                sheet->m_operation.sidebarWidthChanged = dup.value("sidebarWidthChanged").toInt() != 0;
+                sheet->m_operation.scrollPosition = dup.value("scrollPosition").toFloat();
+                QString expandedJson = dup.value("expandedSections").toString();
+                QJsonDocument expDoc = QJsonDocument::fromJson(expandedJson.toUtf8());
+                if (expDoc.isArray()) {
+                    sheet->m_operation.expandedSections.clear();
+                    for (const QJsonValue &val : expDoc.array()) {
+                        sheet->m_operation.expandedSections.append(val.toString());
+                    }
+                }
+                curLastOpened = dupLastOpened;
+            } else {
+                qCWarning(appLog) << "Failed to apply duplicate record state:" << updQuery.lastError();
+            }
+        }
+
+        // 源路径文件已不存在（移动/重命名残留）：其书签并入当前路径
+        // （书签以 路径+指纹 为关联键，跨路径不会自动共享，须显式迁移；
+        //  与记录指纹不符的旧书签留在原路径，由无主书签清理兜底）
+        QSqlQuery bmQuery(m_database);
+        bmQuery.prepare("UPDATE bookmark SET filePath = :newPath "
+                        "WHERE filePath = :oldPath "
+                        "AND (contentHash = :contentHash OR contentHash = '')");
+        bmQuery.bindValue(":newPath", newPath);
+        bmQuery.bindValue(":oldPath", oldPath);
+        bmQuery.bindValue(":contentHash", dup.value("contentHash").toString());
+        if (!bmQuery.exec()) {
+            qCWarning(appLog) << "Failed to migrate bookmarks during merge:" << bmQuery.lastError();
+        }
+
+        // 删除旧路径 operation 记录（书签已并入当前路径）
+        QSqlQuery delQuery(m_database);
+        delQuery.prepare("DELETE FROM operation WHERE filePath = :oldPath");
+        delQuery.bindValue(":oldPath", oldPath);
+        if (delQuery.exec()) {
+            mergedAny = true;
+        } else {
+            qCWarning(appLog) << "Failed to remove duplicate record:" << delQuery.lastError();
+        }
+    }
+
+    if (!mergedAny) {
+        // 源文件均仍存在：同内容多路径独立共存，保留各自记录
+        qCInfo(appLog) << "No duplicate merged, all source files still present:" << newPath;
+        return false;
+    }
+
+    mergeTransaction.commit();
+    qCInfo(appLog) << "Duplicate content records merged: path=" << newPath;
     return true;
 }
 
@@ -538,8 +801,78 @@ int Database::cleanupOrphanStates()
     }
     transaction.commit();
 
+    // 书签以内容指纹为关联键后，其生命周期与内容对齐：
+    // 同一指纹的 operation 记录已全部消失（该内容不再有任何阅读记录），
+    // 且书签记录挂载的所有路径文件均已不存在，则视为无主书签，一并清理。
+    // 任一挂载路径文件仍存在（如同名覆盖后原文件从回收站恢复）则保留，
+    // 待用户打开后按指纹自动找回；可移动设备/网络路径不可靠（可能未挂载），跳过。
+    // 注意需在上方 operation 孤立清理之后执行，判定结果才反映清理后的状态。
+    cleanedCount += cleanupOrphanBookmarks();
+
     qCInfo(appLog) << "Cleaned" << cleanedCount << "orphan state records";
     return cleanedCount;
+}
+
+int Database::cleanupOrphanBookmarks()
+{
+    // 1) 找出已无任何 operation 记录对应的指纹（该内容不再有阅读记录）
+    QSqlQuery hashQuery(m_database);
+    if (!hashQuery.exec("SELECT DISTINCT contentHash, filePath FROM bookmark "
+                        "WHERE contentHash != '' AND contentHash NOT IN "
+                        "(SELECT DISTINCT contentHash FROM operation)")) {
+        qCWarning(appLog) << "Failed to query orphan bookmark hashes:" << hashQuery.lastError();
+        return 0;
+    }
+
+    // hash -> 挂载路径集合
+    QMultiMap<QString, QString> orphanCandidates;
+    while (hashQuery.next()) {
+        orphanCandidates.insert(hashQuery.value(0).toString(), hashQuery.value(1).toString());
+    }
+    if (orphanCandidates.isEmpty()) {
+        return 0;
+    }
+
+    // 2) 逐指纹判定：所有挂载路径的文件均不存在（且不含不可靠路径）才清理
+    QStringList deadHashes;
+    for (auto it = orphanCandidates.constBegin(); it != orphanCandidates.constEnd(); ++it) {
+        bool allGone = true;
+        for (auto pathIt = orphanCandidates.lowerBound(it.key());
+             pathIt != orphanCandidates.upperBound(it.key()); ++pathIt) {
+            const QString &path = pathIt.value();
+            if (Dr::isNetworkPath(path)
+                || path.startsWith("/media/") || path.startsWith("/mnt/")
+                || path.startsWith("/run/media/")) {
+                allGone = false;
+                break;
+            }
+            if (QFile::exists(path)) {
+                allGone = false;
+                break;
+            }
+        }
+        if (allGone) {
+            deadHashes << it.key();
+        }
+    }
+    if (deadHashes.isEmpty()) {
+        return 0;
+    }
+
+    Transaction transaction(m_database);
+    QSqlQuery deleteQuery(m_database);
+    int removed = 0;
+    for (const QString &hash : deadHashes) {
+        deleteQuery.prepare("DELETE FROM bookmark WHERE contentHash = :contentHash");
+        deleteQuery.bindValue(":contentHash", hash);
+        if (deleteQuery.exec()) {
+            removed += qMax(0, deleteQuery.numRowsAffected());
+            qCInfo(appLog) << "Cleaned orphan bookmarks (content no longer tracked): hash="
+                           << hash.left(8) << "rows=" << deleteQuery.numRowsAffected();
+        }
+    }
+    transaction.commit();
+    return removed;
 }
 
 void Database::flushToDisk()
@@ -571,7 +904,9 @@ QString Database::computeContentHash(const QString &filePath)
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
         qCWarning(appLog) << "Cannot open file for hash:" << filePath;
-        return QString();
+        // 注意必须返回非 null 空串：QString() 是 null string，经 QVariant 绑定到
+        // SQLite 会被当作 NULL，导致调用方的 hash 等值比较全部失效
+        return QString(QLatin1String(""));
     }
 
     // 采样头部 64KB + 尾部 64KB，拼接后计算 SHA256
@@ -720,42 +1055,51 @@ bool Database::readBookmarks(const QString &filePath, QSet<int> &bookmarks)
     if (m_database.isOpen()) {
         QSqlQuery query(m_database);
 
-        if (!query.prepare(" select * from bookmark where filePath = :filePath")) {
+        // 书签以「路径 + 内容指纹」为关联键，而非仅内容指纹：
+        // 1) 同一份内容在多个路径共存（本地+U盘拷贝等）时，各路径书签相互独立，
+        //    在任一路径增删书签不会同步到其他路径的同内容文档上；
+        // 2) 文件移动/重命名（源路径文件已不存在）时，书签随阅读状态一起
+        //    迁移到新路径（matchOperationByContent / mergeDuplicateRecords），
+        //    移动后打开新路径仍可找回书签；
+        // 3) 文件内容分叉（如保存高亮注释后指纹变化）后，旧指纹的书签保留在库中，
+        //    原始文件再打开仍可找回，新书签写入新指纹，两者互不干扰；
+        // 4) 同名路径被另一个不同内容的文件覆盖后，旧书签读不出来但保留，
+        //    原文件回来后书签自动恢复。
+        // filePath 仅用于兜底：a) 匹配无指纹的旧版本数据（legacy，读取后回填指纹）；
+        // b) 当前文件不可读（指纹无法计算）时退回按路径读取全部书签（与旧版本行为一致）。
+        // 注意：Qt SQLite 驱动对同名占位符多次出现只绑定第一处，
+        // 同一变量需拆成多个不同名的占位符分别绑定
+        if (!query.prepare("SELECT contentHash, bookmarkIndex FROM bookmark "
+                           "WHERE (filePath = :filePath AND contentHash = :currentHash) "
+                           "OR (:currentHash0 = '' AND filePath = :filePath0) "
+                           "OR (filePath = :filePath1 AND contentHash = '')")) {
             qCInfo(appLog) << query.lastError();
             return false;
         }
+        const QString currentHash = computeContentHash(filePath);
+        query.bindValue(":currentHash", currentHash);
+        query.bindValue(":currentHash0", currentHash);
         query.bindValue(":filePath", filePath);
+        query.bindValue(":filePath0", filePath);
+        query.bindValue(":filePath1", filePath);
 
         if (!query.exec()) {
             qCInfo(appLog) << query.lastError().text();
             return false;
         }
 
-        // 内容指纹校验：同名路径下换了文件（删除重命名、覆盖等）不应继承旧文件的书签。
-        // 保存书签时记录了当时文件的内容哈希，读取时与当前文件哈希比对。
-        const QString currentHash = computeContentHash(filePath);
-        const bool canVerify = !currentHash.isEmpty();
-
-        QStringList staleIndexes;   // 指纹不匹配的过期书签（属于旧文件）
-        bool hasLegacyRows = false; // 旧版本数据（无指纹）
+        // 旧版本数据（无指纹）：批量回填当前文件指纹，后续打开即可按指纹读取
+        // （backfill 使 legacy 书签并入当前内容指纹的书签世界，
+        //  放在遍历结束后执行，避免在 SELECT 迭代过程中写库）
+        bool hasLegacyRows = false;
         while (query.next()) {
-            const int index = query.value("bookmarkIndex").toInt();
-            const QString rowHash = query.value("contentHash").toString();
-            if (canVerify && !rowHash.isEmpty() && rowHash != currentHash) {
-                qCInfo(appLog) << "Stale bookmark dropped (content mismatch):" << filePath
-                                << "page" << index;
-                staleIndexes << QString::number(index);
-                continue;
-            }
-            bookmarks.insert(index);
-            if (canVerify && rowHash.isEmpty()) {
+            bookmarks.insert(query.value("bookmarkIndex").toInt());
+            if (query.value("contentHash").toString().isEmpty()) {
                 hasLegacyRows = true;
             }
         }
 
-        // 旧版本数据（无指纹）：批量回填当前文件指纹，后续打开即可校验
-        // （放在遍历结束后执行，避免在 SELECT 迭代过程中写库）
-        if (hasLegacyRows) {
+        if (hasLegacyRows && !currentHash.isEmpty()) {
             QSqlQuery backfill(m_database);
             backfill.prepare("UPDATE bookmark SET contentHash = :contentHash "
                              "WHERE filePath = :filePath AND contentHash = ''");
@@ -763,17 +1107,6 @@ bool Database::readBookmarks(const QString &filePath, QSet<int> &bookmarks)
             backfill.bindValue(":filePath", filePath);
             if (!backfill.exec()) {
                 qCWarning(appLog) << "Failed to backfill bookmark contentHash:" << backfill.lastError();
-            }
-        }
-
-        // 清除属于旧文件的过期书签，避免残留
-        if (!staleIndexes.isEmpty()) {
-            QSqlQuery delQuery(m_database);
-            delQuery.prepare(QString("DELETE FROM bookmark WHERE filePath = :filePath "
-                                     "AND bookmarkIndex IN (%1)").arg(staleIndexes.join(",")));
-            delQuery.bindValue(":filePath", filePath);
-            if (!delQuery.exec()) {
-                qCWarning(appLog) << "Failed to remove stale bookmarks:" << delQuery.lastError();
             }
         }
 
@@ -790,20 +1123,34 @@ bool Database::saveBookmarks(const QString &filePath, const QSet<int> bookmarks)
 
         Transaction transaction(m_database);
 
-        if (!query.prepare("delete from bookmark where filePath = :filePath")) {
-            qCInfo(appLog) << query.lastError();
-            return false;
+        // 记录当前文件内容指纹：书签以「路径 + 内容指纹」为关联键（跟路径下的内容走）
+        const QString contentHash = computeContentHash(filePath);
+
+        if (!contentHash.isEmpty()) {
+            // 按 路径+指纹 全量替换：仅删除当前路径当前指纹（及无指纹 legacy 行）的书签。
+            // 关键一：其他路径同内容拷贝的书签不受影响（各路径独立，不互相同步）；
+            // 关键二：同一路径其它指纹（历史内容版本）的书签保留 ——
+            // 文件保存高亮注释等内容变化后，旧版本书签仍留存，原始文件/历史版本可找回。
+            if (!query.prepare("DELETE FROM bookmark WHERE filePath = :filePath "
+                               "AND (contentHash = :contentHash OR contentHash = '')")) {
+                qCInfo(appLog) << query.lastError();
+                return false;
+            }
+        } else {
+            // 指纹不可用（文件不可读等）：退回路径维度删除（legacy 行为）
+            if (!query.prepare("DELETE FROM bookmark WHERE filePath = :filePath")) {
+                qCInfo(appLog) << query.lastError();
+                return false;
+            }
         }
 
+        query.bindValue(":contentHash", contentHash);
         query.bindValue(":filePath", filePath);
 
         if (!query.exec()) {
             qCInfo(appLog) << query.lastError().text();
             return false;
         }
-
-        // 记录当前文件内容指纹，供读取时校验书签是否属于该文件
-        const QString contentHash = computeContentHash(filePath);
 
         foreach (int index, bookmarks) {
             if (!query.prepare(" insert into "

--- a/reader/app/Database.h
+++ b/reader/app/Database.h
@@ -56,8 +56,10 @@ public:
 
     /**
      * @brief readBookmarks
-     * 读取书签（带内容指纹校验：同名但内容不同的文件不会继承旧文件的书签）
-     * @param filePath 文件名(唯一标识)
+     * 读取书签（以 路径+内容指纹 为关联键：同内容文件在不同路径各自独立一套书签，
+     * 互不同步；文件移动/重命名后书签随阅读状态迁移到新路径；
+     * 内容分叉（保存注释）后各版本书签独立保留；同名不同内容的文件不会读到无关书签）
+     * @param filePath 文件名(与指纹共同作为关联键，另用于 legacy 无指纹书签兜底)
      * @param bookmarks 书签列表
      * @return
      */
@@ -65,8 +67,10 @@ public:
 
     /**
      * @brief saveBookmarks
-     * 保存书签（同时记录当前文件内容指纹，供读取时校验）
-     * @param filePath 文件名(唯一标识)
+     * 保存书签（按 路径+指纹 全量替换该书签集合；
+     * 其他路径同内容拷贝的书签不受影响；同路径其它内容指纹的
+     * 历史版本书签保留，不随保存删除）
+     * @param filePath 文件名(与指纹共同作为关联键)
      * @param bookmarks 书签列表
      * @return
      */
@@ -105,8 +109,13 @@ public:
 
     /**
      * @brief matchOperationByContent
-     * 通过文件内容特征（大小+修改时间+内容哈希）匹配已保存的操作记录
-     * 用于文档移动或重命名后仍能恢复阅读状态
+     * 通过文件内容特征（docId 优先，其次 fileSize+内容哈希）匹配已保存的操作记录，
+     * 用于目标路径自身无记录时恢复阅读状态。两种命中方式：
+     * 1. 迁移：源文件已确认不存在（可靠的本地路径经存在性确认），
+     *    视为移动/重命名，记录与书签整体迁移到新路径；
+     * 2. 首开借用：源文件仍存在（复制到U盘等副本场景），仅把源状态
+     *    与匹配指纹的书签复制一份给新路径，源路径记录一行不动 ——
+     *    新路径关闭落盘自己的记录后与源路径各自独立，避免互相覆盖
      * @param fileInfo 文件信息
      * @param sheet 目标sheet，匹配成功后写入其operation
      * @return 是否匹配成功
@@ -121,10 +130,21 @@ public:
      * 带内容指纹的记录不立即删除（文件可能只是被重命名/移动，
      * 需保留供打开新路径时按指纹迁移），改用与网络文档一致的
      * 7 天超时策略；无指纹的旧格式记录维持原删除策略；
-     * 网络文档按超时清理：超过 7 天未打开的记录（含书签）被清除
+     * 网络文档按超时清理：超过 7 天未打开的记录（含书签）被清除。
+     * 书签以内容指纹为关联键后，另追加无主书签清理（见 cleanupOrphanBookmarks）
      * @return 清理的记录数
      */
     int cleanupOrphanStates();
+
+    /**
+     * @brief cleanupOrphanBookmarks
+     * 清理无主书签：同一内容指纹的 operation 记录已全部消失，
+     * 且书签挂载的所有路径文件均已不存在（不含可移动设备/网络等
+     * 存在性不可靠的路径），则该内容的书签一并清理；
+     * 任一挂载路径文件仍存在则保留（待用户打开后按指纹找回）
+     * @return 清理的书签记录数
+     */
+    int cleanupOrphanBookmarks();
 
     /**
      * @brief flushToDisk
@@ -182,6 +202,20 @@ private:
      * @return
      */
     bool migrateBookmarkTable();
+
+    /**
+     * @brief mergeDuplicateRecords
+     * 合并同内容（docId 或 fileSize+contentHash 相同）且源文件已不存在的
+     * 其他路径记录到当前路径，作为文件移动/重命名后状态迁移的收尾
+     * （目标路径已有同内容记录时 matchOperationByContent 不会被调用，
+     * 旧路径残留记录在此清理：阅读状态取 lastOpened 较新者，删除源记录，
+     * 旧路径书签并入当前路径）。
+     * 注意：源文件仍存在的同内容记录不参与合并 —— 同一份内容在多个路径
+     * 同时存在（本地+U盘拷贝、多处复制）时，各路径保持独立阅读状态互不覆盖
+     * @param sheet 当前文档（filePath 为合并目标路径）
+     * @return 是否发生了合并
+     */
+    bool mergeDuplicateRecords(DocSheet *sheet);
 
     QSqlDatabase m_database;
 

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -1516,6 +1516,12 @@ void DocSheet::onBrowserPageChanged(int page)
         qCInfo(appLog) << "onBrowserPageChanged ignored during restore guard, anchorPage=" << m_restoreAnchorPage;
         return;
     }
+    // 非当前页签（不可见）时用户无法滚动，页码变化必是布局/程序行为，
+    // 回写会污染保存的阅读进度（多文档启动期尤甚）
+    if (m_browser && !m_browser->isVisible()) {
+        qCInfo(appLog) << "onBrowserPageChanged ignored: sheet not visible, page=" << page;
+        return;
+    }
     if (m_operation.currentPage != page) {
         m_operation.currentPage = page;
         if (m_sidebar)
@@ -1565,7 +1571,7 @@ void DocSheet::onBrowserOperaAnnotation(int type, int index, deepin_reader::Anno
     setDocumentChanged(true);
 
     if (m_autoSaveTimer) {
-        m_autoSaveTimer->start(0);
+        m_autoSaveTimer->start(100);
     }
 }
 
@@ -1903,6 +1909,14 @@ void DocSheet::onLayoutSettled()
 {
     if (!m_restoreGuardActive)
         return;
+
+    // 页签尚不可见（启动期多文档交替恢复）：滚动条范围是陈旧布局的，
+    // 此刻恢复无效且产生中间态，顺延到页签可见后（deform 会重启计时）再恢复
+    if (m_browser && !m_browser->isVisible()) {
+        m_restoreSettleTimer->start(kRestoreSettleMs);
+        return;
+    }
+
     m_restoreGuardActive = false;
 
     if (m_browser && opened() && m_operation.scrollPosition > 0.0f) {

--- a/tests/app/ut_database.cpp
+++ b/tests/app/ut_database.cpp
@@ -217,6 +217,16 @@ static qint64 ut_bookmark_count(Database *db, const QString &filePath)
     return query.value(0).toLongLong();
 }
 
+static qint64 ut_bookmark_hash_count(Database *db, const QString &hash)
+{
+    QSqlQuery query(db->m_database);
+    query.prepare("SELECT COUNT(*) FROM bookmark WHERE contentHash = :h");
+    query.bindValue(":h", hash);
+    query.exec();
+    query.next();
+    return query.value(0).toLongLong();
+}
+
 TEST_F(TestDatabase, UT_Database_cleanupOrphanStates_002)
 {
     // 网络文档超时清理：lastOpened 超过 7 天的记录及书签应被清理
@@ -358,6 +368,150 @@ TEST_F(TestDatabase, UT_Database_cleanupOrphanStates_004)
     QFile::remove(doc);
 }
 
+TEST_F(TestDatabase, UT_Database_cleanupOrphanBookmarks_001)
+{
+    // 书签以内容指纹为关联键后的无主书签清理：
+    // 1) 同指纹的 operation 记录已全部消失，且挂载路径文件不存在 → 清理；
+    // 2) 指纹仍有 operation 记录（文件不存在待迁移）→ 保留；
+    // 3) 挂载路径为可移动设备（可能未挂载，存在性不可靠）→ 保留；
+    // 4) legacy 无指纹书签不受影响，仍走原有路径清理策略
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    const QString deadPath = dir + "/orphan_bm_dead.pdf";      // 不创建文件
+    const QString alivePath = dir + "/orphan_bm_alive.pdf";    // 不创建文件，但指纹有主
+    const QString mediaPath = "/media/usb0/orphan_bm_media.pdf";
+    const QString legacyPath = dir + "/orphan_bm_legacy.pdf";
+    const QString deadHash = "fakehash_bm001_dead";
+    const QString aliveHash = "fakehash_bm001_alive";
+    const QString mediaHash = "fakehash_bm001_media";
+
+    QSqlQuery query(m_tester->m_database);
+    auto cleanOne = [&](const QString &p) {
+        query.prepare("DELETE FROM operation WHERE filePath = :p");
+        query.bindValue(":p", p);
+        ASSERT_TRUE(query.exec());
+        query.prepare("DELETE FROM bookmark WHERE filePath = :p");
+        query.bindValue(":p", p);
+        ASSERT_TRUE(query.exec());
+    };
+    for (const QString &p : { deadPath, alivePath, legacyPath }) {
+        cleanOne(p);
+    }
+    for (const QString &h : { deadHash, aliveHash, mediaHash }) {
+        query.prepare("DELETE FROM bookmark WHERE contentHash = :h");
+        query.bindValue(":h", h);
+        ASSERT_TRUE(query.exec());
+    }
+
+    // 1) 无主指纹 + 文件不存在 → 应清理
+    query.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) "
+                  "VALUES(:p, 0, :h)");
+    query.bindValue(":p", deadPath);
+    query.bindValue(":h", deadHash);
+    ASSERT_TRUE(query.exec());
+
+    // 2) 指纹有主（operation 保留待迁移）→ 书签应保留
+    query.prepare("INSERT INTO operation(filePath, contentHash, lastOpened) "
+                  "VALUES(:p, :h, :t)");
+    query.bindValue(":p", alivePath);
+    query.bindValue(":h", aliveHash);
+    query.bindValue(":t", QDateTime::currentMSecsSinceEpoch());
+    ASSERT_TRUE(query.exec());
+    query.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) "
+                  "VALUES(:p, 1, :h)");
+    query.bindValue(":p", alivePath);
+    query.bindValue(":h", aliveHash);
+    ASSERT_TRUE(query.exec());
+
+    // 3) 可移动设备路径：文件不存在但不可靠 → 保留
+    query.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) "
+                  "VALUES(:p, 2, :h)");
+    query.bindValue(":p", mediaPath);
+    query.bindValue(":h", mediaHash);
+    ASSERT_TRUE(query.exec());
+
+    // 4) legacy：无指纹 operation + 无指纹书签 + 文件不存在 → 原逻辑立即清理
+    query.prepare("INSERT INTO operation(filePath, contentHash, lastOpened) "
+                  "VALUES(:p, '', :t)");
+    query.bindValue(":p", legacyPath);
+    query.bindValue(":t", QDateTime::currentMSecsSinceEpoch());
+    ASSERT_TRUE(query.exec());
+    query.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) "
+                  "VALUES(:p, 3, '')");
+    query.bindValue(":p", legacyPath);
+    ASSERT_TRUE(query.exec());
+
+    m_tester->cleanupOrphanStates();
+
+    // 1) 清理
+    EXPECT_EQ(ut_bookmark_hash_count(m_tester, deadHash), 0);
+    // 2) 保留（书签与待迁移的阅读状态一起等待内容重现）
+    EXPECT_EQ(ut_bookmark_hash_count(m_tester, aliveHash), 1);
+    EXPECT_EQ(ut_operation_count(m_tester, alivePath), 1);
+    // 3) 保留
+    EXPECT_EQ(ut_bookmark_hash_count(m_tester, mediaHash), 1);
+    // 4) legacy 清理
+    EXPECT_EQ(ut_bookmark_count(m_tester, legacyPath), 0);
+    EXPECT_EQ(ut_operation_count(m_tester, legacyPath), 0);
+
+    // 尾部清理：避免持久库残留干扰后续用例
+    for (const QString &p : { alivePath, legacyPath }) {
+        cleanOne(p);
+    }
+    for (const QString &h : { deadHash, aliveHash, mediaHash }) {
+        query.prepare("DELETE FROM bookmark WHERE contentHash = :h");
+        query.bindValue(":h", h);
+        ASSERT_TRUE(query.exec());
+    }
+}
+
+TEST_F(TestDatabase, UT_Database_cleanupOrphanBookmarks_002)
+{
+    // 无主指纹但挂载路径文件仍存在 → 保留
+    // （同名覆盖后原文件从回收站恢复的场景：书签隐身保留，打开后按指纹找回）
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString doc = dir + "/orphan_bm_kept.pdf";
+    QFile::remove(doc);
+    ASSERT_TRUE(QFile::copy(src, doc));
+    // 用假指纹保证无主且不与其他用例的真实指纹串扰
+    const QString fakeHash = "fakehash_bm002_kept";
+
+    QSqlQuery query(m_tester->m_database);
+    query.prepare("DELETE FROM operation WHERE filePath = :p");
+    query.bindValue(":p", doc);
+    ASSERT_TRUE(query.exec());
+    query.prepare("DELETE FROM bookmark WHERE filePath = :p");
+    query.bindValue(":p", doc);
+    ASSERT_TRUE(query.exec());
+    query.prepare("DELETE FROM bookmark WHERE contentHash = :h");
+    query.bindValue(":h", fakeHash);
+    ASSERT_TRUE(query.exec());
+
+    // 文件存在但没有 operation 记录（同名覆盖后残留的旧内容书签）
+    query.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) "
+                  "VALUES(:p, 4, :h)");
+    query.bindValue(":p", doc);
+    query.bindValue(":h", fakeHash);
+    ASSERT_TRUE(query.exec());
+
+    m_tester->cleanupOrphanStates();
+
+    // 挂载路径文件存在 → 无主书签保留
+    EXPECT_EQ(ut_bookmark_hash_count(m_tester, fakeHash), 1);
+
+    // 尾部清理
+    query.prepare("DELETE FROM bookmark WHERE contentHash = :h");
+    query.bindValue(":h", fakeHash);
+    ASSERT_TRUE(query.exec());
+    query.prepare("DELETE FROM bookmark WHERE filePath = :p");
+    query.bindValue(":p", doc);
+    ASSERT_TRUE(query.exec());
+    QFile::remove(doc);
+}
+
 TEST_F(TestDatabase, UT_Database_renameBookmarkMigration_001)
 {
     // 端到端：文件重命名 → 启动清理不再误删旧记录 →
@@ -389,10 +543,11 @@ TEST_F(TestDatabase, UT_Database_renameBookmarkMigration_001)
     EXPECT_EQ(ut_operation_count(m_tester, doc1), 1);
     EXPECT_EQ(ut_bookmark_count(m_tester, doc1), 1);
 
-    // 打开新路径：内容匹配迁移，书签与阅读状态都跟随
+    // 打开新路径：内容匹配迁移阅读状态；书签随迁移一并转到新路径
     EXPECT_TRUE(m_tester->matchOperationByContent(QFileInfo(docMoved), &sheet));
     EXPECT_EQ(ut_operation_count(m_tester, doc1), 0);
     EXPECT_EQ(ut_bookmark_count(m_tester, doc1), 0);
+    EXPECT_EQ(ut_bookmark_count(m_tester, docMoved), 1);
 
     QSet<int> bookmarks;
     EXPECT_TRUE(m_tester->readBookmarks(docMoved, bookmarks));
@@ -409,6 +564,27 @@ TEST_F(TestDatabase, UT_Database_renameBookmarkMigration_001)
 }
 
 // ===== 书签内容指纹校验 =====
+
+// 按内容指纹清理书签记录（书签跨路径读取，固定路径的用例间会通过同 hash 内容互相污染）
+static void ut_cleanup_content(Database *db, const QString &hash)
+{
+    QSqlQuery query(db->m_database);
+    query.prepare("DELETE FROM bookmark WHERE contentHash = :h");
+    query.bindValue(":h", hash);
+    ASSERT_TRUE(query.exec());
+}
+
+// 清理指定路径的 operation/bookmark 记录（测试库持久共享，避免用例间串扰）
+static void ut_cleanup_path(Database *db, const QString &path)
+{
+    QSqlQuery query(db->m_database);
+    query.prepare("DELETE FROM operation WHERE filePath = :p");
+    query.bindValue(":p", path);
+    ASSERT_TRUE(query.exec());
+    query.prepare("DELETE FROM bookmark WHERE filePath = :p");
+    query.bindValue(":p", path);
+    ASSERT_TRUE(query.exec());
+}
 
 // 准备临时目录及两个内容不同的真实文件（computeContentHash 需要读取文件）
 static QString ut_bookmark_prepare_files(QString &doc1, QString &doc2)
@@ -439,6 +615,9 @@ TEST_F(TestDatabase, UT_Database_bookmarkContentHash_001)
     ut_bookmark_prepare_files(doc1, doc2);
     ASSERT_NE(Database::computeContentHash(doc1), Database::computeContentHash(doc2));
 
+    // 测试库持久共享：先清掉同指纹历史残留（书签跨路径读取，会互相污染）
+    ut_cleanup_content(m_tester, Database::computeContentHash(doc1));
+
     // 文档1 第 1 页添加书签，正常读取
     ASSERT_TRUE(m_tester->saveBookmarks(doc1, QSet<int> {0}));
     QSet<int> read;
@@ -449,12 +628,15 @@ TEST_F(TestDatabase, UT_Database_bookmarkContentHash_001)
     QFile::remove(doc1);
     ASSERT_TRUE(QFile::rename(doc2, doc1));
 
-    // 旧文件的书签不应出现在新文件上，且过期记录已被清除
+    // 旧文件的书签不应出现在新文件上；记录按指纹保留在库中（隐身），
+    // 原内容恢复后书签可自动找回
     read.clear();
     EXPECT_TRUE(m_tester->readBookmarks(doc1, read));
     EXPECT_TRUE(read.isEmpty());
-    EXPECT_EQ(ut_bookmark_count(m_tester, doc1), 0);
+    EXPECT_EQ(ut_bookmark_count(m_tester, doc1), 1);
 
+    // 清理残留（doc1 现为 doc2 内容，其指纹无书签记录，清理 doc1 路径即可）
+    ut_cleanup_path(m_tester, doc1);
     QFile::remove(doc1);
 }
 
@@ -548,6 +730,9 @@ TEST_F(TestDatabase, UT_Database_bookmarkContentHash_002)
     ut_bookmark_prepare_files(doc1, doc2);
     QFile::remove(doc2);
 
+    // 测试库持久共享：清理同指纹历史残留
+    ut_cleanup_content(m_tester, Database::computeContentHash(doc1));
+
     // 直接插入一条无指纹的旧格式记录
     QSqlQuery insert(m_tester->m_database);
     insert.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) VALUES(:p, :i, '')");
@@ -572,6 +757,7 @@ TEST_F(TestDatabase, UT_Database_bookmarkContentHash_002)
     EXPECT_TRUE(m_tester->readBookmarks(doc1, read));
     EXPECT_EQ(read, QSet<int> {3});
 
+    ut_cleanup_content(m_tester, Database::computeContentHash(doc1));
     QFile::remove(doc1);
 }
 
@@ -581,6 +767,9 @@ TEST_F(TestDatabase, UT_Database_bookmarkContentHash_003)
     QString doc1, doc2;
     ut_bookmark_prepare_files(doc1, doc2);
     QFile::remove(doc2);
+
+    // 测试库持久共享：清理同指纹历史残留
+    ut_cleanup_content(m_tester, Database::computeContentHash(doc1));
 
     ASSERT_TRUE(m_tester->saveBookmarks(doc1, QSet<int> {2}));
 
@@ -593,5 +782,540 @@ TEST_F(TestDatabase, UT_Database_bookmarkContentHash_003)
     EXPECT_EQ(ut_bookmark_count(m_tester, doc1), 1);
 
     QFile::setPermissions(doc1, QFile::ReadOwner | QFile::WriteOwner);
+    // 清理残留：无权限期间 saveBookmarks 按路径删除并写入无指纹记录
+    ut_cleanup_path(m_tester, doc1);
+    ut_cleanup_content(m_tester, Database::computeContentHash(doc1));
     QFile::remove(doc1);
+}
+
+// ===== 同内容多路径记录合并（文件移动/复制到已存在同名旧记录的路径） =====
+
+// 以 SQL 直写一条 operation 记录。
+// 注意：不要用 DocSheet 构造来造记录 —— 其构造即 setAlive(true)，
+// 会隐式触发 readOperation/matchOperationByContent 提前迁移同内容记录，污染场景
+static void ut_insert_operation(Database *db, const QString &path, int currentPage,
+                                const QString &hash, qint64 lastOpened)
+{
+    // fileSize 必须写真实值：matchOperationByContent / mergeDuplicateRecords
+    // 均按 fileSize+contentHash 匹配，写默认值 0 会导致匹配不上
+    QSqlQuery insert(db->m_database);
+    insert.prepare("INSERT INTO operation(filePath, currentPage, contentHash, lastOpened, fileSize) "
+                   "VALUES(:p, :c, :h, :t, :s)");
+    insert.bindValue(":p", path);
+    insert.bindValue(":c", currentPage);
+    insert.bindValue(":h", hash);
+    insert.bindValue(":t", lastOpened);
+    insert.bindValue(":s", QFileInfo(path).size());
+    ASSERT_TRUE(insert.exec());
+}
+
+TEST_F(TestDatabase, UT_Database_mergeDuplicateRecords_001)
+{
+    // bug 场景：本地与U盘存在同一份文档（内容相同），U盘路径已有旧记录（无书签），
+    // 本地文档加书签/进度后移动到U盘替换，重新打开U盘文档时
+    // readOperation 命中U盘旧记录且指纹校验通过，应触发同内容记录合并：
+    // 书签迁移、进度恢复为带书签记录（本地）的状态、旧路径记录清理
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString docLocal = dir + "/merge_local.pdf";
+    const QString docUsb = dir + "/merge_usb.pdf";
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+    ASSERT_TRUE(QFile::copy(src, docLocal));
+    ASSERT_TRUE(QFile::copy(src, docUsb));
+    const QString hash = Database::computeContentHash(docLocal);
+    ASSERT_EQ(hash, Database::computeContentHash(docUsb));
+
+    // 幂等清理历史残留（残留记录会干扰内容匹配）
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+
+    // U盘文档曾打开过，留下旧记录（currentPage=2，无书签）
+    {
+        DocSheet sheetUsb(Dr::FileType::PDF, docUsb, nullptr);
+        sheetUsb.m_operation.currentPage = 2;
+        ASSERT_TRUE(m_tester->saveOperation(&sheetUsb, hash));
+    }
+
+    // 本地文档：阅读到第3页、书签{0,2,4}，正常关闭落库（SQL 直写）
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    ut_insert_operation(m_tester, docLocal, 3, hash, now);
+    ASSERT_TRUE(m_tester->saveBookmarks(docLocal, QSet<int> {0, 2, 4}));
+
+    // 文件移动到U盘替换（内容不变）：本地源文件已不存在，
+    // 重新打开U盘文档才会触发同内容记录合并（源文件仍存在时各自独立）
+    ASSERT_TRUE(QFile::remove(docLocal));
+
+    // readOperation 命中U盘旧记录，合并后应恢复本地文档的状态（带书签的记录优先）
+    {
+        DocSheet sheetUsbAgain(Dr::FileType::PDF, docUsb, nullptr);
+        EXPECT_TRUE(m_tester->readOperation(&sheetUsbAgain));
+        EXPECT_EQ(sheetUsbAgain.m_operation.currentPage, 3);
+    }
+
+    // 书签随合并迁移到U盘路径（源文件已不存在，书签跟文档走）
+    QSet<int> bookmarks;
+    EXPECT_TRUE(m_tester->readBookmarks(docUsb, bookmarks));
+    EXPECT_EQ(bookmarks, (QSet<int> {0, 2, 4}));
+    // 书签已并入U盘路径，本地路径不再残留书签与 operation 记录
+    EXPECT_EQ(ut_bookmark_count(m_tester, docLocal), 0);
+    EXPECT_EQ(ut_bookmark_count(m_tester, docUsb), 3);
+    EXPECT_EQ(ut_operation_count(m_tester, docLocal), 0);
+    EXPECT_EQ(ut_operation_count(m_tester, docUsb), 1);
+
+    ut_cleanup_path(m_tester, docUsb);
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+}
+
+TEST_F(TestDatabase, UT_Database_mergeDuplicateRecords_002)
+{
+    // 两边都有书签：书签并集去重，状态取 lastOpened 较新者
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString docLocal = dir + "/merge2_local.pdf";
+    const QString docUsb = dir + "/merge2_usb.pdf";
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+    ASSERT_TRUE(QFile::copy(src, docLocal));
+    ASSERT_TRUE(QFile::copy(src, docUsb));
+    const QString hash = Database::computeContentHash(docLocal);
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    // U盘旧记录：书签{0,2}，lastOpened 较旧
+    ut_insert_operation(m_tester, docUsb, 2, hash, now - 60000);
+    ASSERT_TRUE(m_tester->saveBookmarks(docUsb, QSet<int> {0, 2}));
+    // 本地记录：lastOpened 较新；书签按路径独立，本地会话初始不继承U盘书签，
+    // 会话中自行添加 {0,2,4}，保存时写入本地路径
+    ut_insert_operation(m_tester, docLocal, 7, hash, now);
+    QSet<int> localSession;
+    EXPECT_TRUE(m_tester->readBookmarks(docLocal, localSession));
+    EXPECT_TRUE(localSession.isEmpty());
+    ASSERT_TRUE(m_tester->saveBookmarks(docLocal, QSet<int> {0, 2, 4}));
+
+    // 文件移动场景：本地源文件已不存在（源文件仍存在时各自独立，不合并）
+    ASSERT_TRUE(QFile::remove(docLocal));
+
+    {
+        DocSheet sheetUsbAgain(Dr::FileType::PDF, docUsb, nullptr);
+        EXPECT_TRUE(m_tester->readOperation(&sheetUsbAgain));
+        // 两边都有书签 → lastOpened 较新的 local 优先
+        EXPECT_EQ(sheetUsbAgain.m_operation.currentPage, 7);
+    }
+
+    // 书签按内容指纹共享：并集 {0,2,4}，无重复页
+    QSet<int> bookmarks;
+    EXPECT_TRUE(m_tester->readBookmarks(docUsb, bookmarks));
+    EXPECT_EQ(bookmarks, (QSet<int> {0, 2, 4}));
+    EXPECT_EQ(ut_operation_count(m_tester, docLocal), 0);
+
+    ut_cleanup_path(m_tester, docUsb);
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+}
+
+TEST_F(TestDatabase, UT_Database_mergeDuplicateRecords_003)
+{
+    // 都无书签：取 lastOpened 较新者；同时验证 docId 匹配分支（hash 不同、docId 相同）
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString docLocal = dir + "/merge3_local.pdf";
+    const QString docUsb = dir + "/merge3_usb.pdf";
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+    ASSERT_TRUE(QFile::copy(src, docLocal));
+    // 追加数据使 hash 不同，但 docId 相同（模拟同一文档的不同修改版本）
+    ASSERT_TRUE(QFile::copy(src, docUsb));
+    {
+        QFile f(docUsb);
+        ASSERT_TRUE(f.open(QIODevice::Append));
+        f.write(QByteArray(4096, 'y'));
+    }
+    const QString hashUsb = Database::computeContentHash(docUsb);
+    const QString hashLocal = Database::computeContentHash(docLocal);
+    ASSERT_NE(hashUsb, hashLocal);
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    // U盘记录：较新（currentPage=9）
+    ut_insert_operation(m_tester, docUsb, 9, hashUsb, now);
+    // 本地记录：较旧（currentPage=3），docId 与U盘记录相同
+    ut_insert_operation(m_tester, docLocal, 3, hashLocal, now - 60000);
+    QSqlQuery setDocId(m_tester->m_database);
+    ASSERT_TRUE(setDocId.exec("UPDATE operation SET docId = 'ut-merge-docid' "
+                              "WHERE filePath IN ('" + docUsb + "', '" + docLocal + "')"));
+    ASSERT_EQ(setDocId.numRowsAffected(), 2);
+
+    // 文件移动场景：本地源文件已不存在（源文件仍存在时各自独立，不合并）
+    ASSERT_TRUE(QFile::remove(docLocal));
+
+    {
+        DocSheet sheetUsbAgain(Dr::FileType::PDF, docUsb, nullptr);
+        EXPECT_TRUE(m_tester->readOperation(&sheetUsbAgain));
+        // docId 匹配到 local 记录，但其 lastOpened 较旧且无书签 → 状态保持U盘自己的（较新）
+        EXPECT_EQ(sheetUsbAgain.m_operation.currentPage, 9);
+    }
+
+    // 同 docId 的旧路径记录已清理
+    EXPECT_EQ(ut_operation_count(m_tester, docLocal), 0);
+
+    ut_cleanup_path(m_tester, docUsb);
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+}
+
+TEST_F(TestDatabase, UT_Database_matchContentUsbExisting_001)
+{
+    // matchOperationByContent 目标路径已有旧记录（同名替换场景）：
+    // 迁移 UPDATE 不应再因 operation.filePath 主键冲突而失败，
+    // 且目标路径/源路径下与当前内容不符的遗留旧书签不应被迁移
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString docLocal = dir + "/mc_local.pdf";
+    const QString docUsb = dir + "/mc_usb.pdf";
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+    ASSERT_TRUE(QFile::copy(src, docLocal));
+    ASSERT_TRUE(QFile::copy(src, docUsb));
+    const QString hash = Database::computeContentHash(docLocal);
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+
+    // 先构造 sheet（此时库中无记录，构造时的隐式匹配不会迁移任何数据）
+    DocSheet sheet(Dr::FileType::PDF, docUsb, nullptr);
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    // U盘旧记录：无书签，另遗留一份与当前内容不符的旧书签（模拟旧文件残留）
+    ut_insert_operation(m_tester, docUsb, 2, hash, now - 60000);
+    QSqlQuery staleBm(m_tester->m_database);
+    staleBm.prepare("INSERT INTO bookmark(filePath, bookmarkIndex, contentHash) VALUES(:p, 8, 'stale-hash')");
+    staleBm.bindValue(":p", docUsb);
+    ASSERT_TRUE(staleBm.exec());
+
+    // 本地记录：书签+进度
+    ut_insert_operation(m_tester, docLocal, 3, hash, now);
+    ASSERT_TRUE(m_tester->saveBookmarks(docLocal, QSet<int> {0, 2, 4}));
+
+    // 文件移动场景：本地源文件已不存在，迁移才会发生（仍存在时不夺走其记录）
+    ASSERT_TRUE(QFile::remove(docLocal));
+
+    // 直接触发内容匹配迁移（模拟 readOperation miss 后的兜底路径）
+    EXPECT_TRUE(m_tester->matchOperationByContent(QFileInfo(docUsb), &sheet));
+    EXPECT_EQ(sheet.m_operation.currentPage, 3);
+
+    // 旧路径记录清理；书签随内容匹配迁移到新路径，旧 hash 脏书签读不出来
+    QSet<int> bookmarks;
+    EXPECT_TRUE(m_tester->readBookmarks(docUsb, bookmarks));
+    EXPECT_EQ(bookmarks, (QSet<int> {0, 2, 4}));
+    EXPECT_EQ(ut_operation_count(m_tester, docLocal), 0);
+    EXPECT_EQ(ut_bookmark_count(m_tester, docLocal), 0);
+    // U盘路径：迁移来的 3 条 + 遗留的 1 条 stale-hash 脏书签（读不出来）
+    EXPECT_EQ(ut_bookmark_count(m_tester, docUsb), 4);
+
+    ut_cleanup_path(m_tester, docUsb);
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+}
+
+// ===== 同内容多路径共存：各路径保持独立阅读状态 =====
+// 场景：本地与U盘（均已挂载）各有一份相同内容的文档，两个路径的记录
+// 互不合并/迁移：打开任一副本读到各自的状态，另一方记录不受影响；
+// 同内容新路径也不得夺走现存路径的记录。
+// （修复前：mergeDuplicateRecords 无条件合并并删除对方记录，导致
+//  两个文档缩放互相覆盖、关闭后只剩一条记录）
+TEST_F(TestDatabase, UT_Database_sameContentCoexistIndependence_001)
+{
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString docLocal = dir + "/coexist_local.pdf";
+    const QString docUsb = dir + "/coexist_usb.pdf";
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+    ASSERT_TRUE(QFile::copy(src, docLocal));
+    ASSERT_TRUE(QFile::copy(src, docUsb));
+    const QString hash = Database::computeContentHash(docLocal);
+    ASSERT_EQ(hash, Database::computeContentHash(docUsb));
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+
+    // 两个路径各自的阅读状态：页码/缩放均不同
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    ut_insert_operation(m_tester, docLocal, 3, hash, now - 60000);
+    ut_insert_operation(m_tester, docUsb, 9, hash, now);
+    QSqlQuery scale(m_tester->m_database);
+    scale.prepare("UPDATE operation SET scaleFactor = 2.0 WHERE filePath = :p");
+    scale.bindValue(":p", docLocal);
+    ASSERT_TRUE(scale.exec());
+
+    // 打开本地副本：读到本地自己的状态（zoom 2.0 / page 3），
+    // 不被U盘记录（较新）覆盖，U盘记录也不被合并删除
+    {
+        DocSheet sheetLocal(Dr::FileType::PDF, docLocal, nullptr);
+        EXPECT_TRUE(m_tester->readOperation(&sheetLocal));
+        EXPECT_EQ(sheetLocal.m_operation.currentPage, 3);
+        EXPECT_EQ(sheetLocal.m_operation.scaleFactor, 2.0);
+        EXPECT_EQ(ut_operation_count(m_tester, docUsb), 1);
+    }
+
+    // 打开U盘副本：读到U盘自己的状态（page 9），本地记录保留
+    {
+        DocSheet sheetUsb(Dr::FileType::PDF, docUsb, nullptr);
+        EXPECT_TRUE(m_tester->readOperation(&sheetUsb));
+        EXPECT_EQ(sheetUsb.m_operation.currentPage, 9);
+        EXPECT_EQ(sheetUsb.m_operation.scaleFactor, 0.1);  // 记录未写缩放，读出钳位默认值，非本地的 2.0
+        EXPECT_EQ(ut_operation_count(m_tester, docLocal), 1);
+    }
+
+    // 第三个路径首开同内容文件（自身无记录）：源文件均仍存在 → 首开借用。
+    // 借用最近修改的源记录（docUsb）的状态，书签复制一份到新路径，
+    // 但不得夺走任一现存路径的记录（不迁移、不新建 operation 行）
+    {
+        const QString docThird = dir + "/coexist_third.pdf";
+        QFile::remove(docThird);
+        ASSERT_TRUE(QFile::copy(src, docThird));
+        ut_cleanup_path(m_tester, docThird);
+        ASSERT_TRUE(m_tester->saveBookmarks(docUsb, QSet<int> {1, 4}));
+        QSqlQuery touch(m_tester->m_database);
+        touch.prepare("UPDATE operation SET lastModified = :t WHERE filePath = :p");
+        touch.bindValue(":t", QDateTime::currentMSecsSinceEpoch());
+        touch.bindValue(":p", docUsb);
+        ASSERT_TRUE(touch.exec());
+
+        DocSheet sheetThird(Dr::FileType::PDF, docThird, nullptr);
+        EXPECT_TRUE(m_tester->matchOperationByContent(QFileInfo(docThird), &sheetThird));
+        // 借用 docUsb 的状态（page 9，缩放未写读出钳位 0.1），非 docLocal（page 3 / zoom 2.0）
+        EXPECT_EQ(sheetThird.m_operation.currentPage, 9);
+        EXPECT_EQ(sheetThird.m_operation.scaleFactor, 0.1);
+        // 现存路径记录不被夺走，借用也不创建新 operation 记录
+        EXPECT_EQ(ut_operation_count(m_tester, docLocal), 1);
+        EXPECT_EQ(ut_operation_count(m_tester, docUsb), 1);
+        EXPECT_EQ(ut_operation_count(m_tester, docThird), 0);
+        // 书签已复制到新路径，源路径书签原样保留
+        EXPECT_EQ(ut_bookmark_count(m_tester, docThird), 2);
+        EXPECT_EQ(ut_bookmark_count(m_tester, docUsb), 2);
+        ut_cleanup_path(m_tester, docThird);
+        QFile::remove(docThird);
+    }
+
+    // 两个副本各自保存关闭后：两条记录仍在，互不覆盖
+    EXPECT_EQ(ut_operation_count(m_tester, docLocal), 1);
+    EXPECT_EQ(ut_operation_count(m_tester, docUsb), 1);
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+}
+
+// QA 用例[2]：本地阅读后关闭（展开缩略图、自定义最小宽度、第4页、加书签），
+// 复制文档到 U 盘后从 U 盘首开：状态与书签应与源文档一致（首开借用）；
+// U 盘关闭落盘自己的记录后，两路径各自独立互不覆盖
+TEST_F(TestDatabase, UT_Database_borrowStateOnFirstOpen_001)
+{
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString docLocal = dir + "/borrow_local.pdf";
+    const QString docUsb = dir + "/borrow_usb.pdf";
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+    ASSERT_TRUE(QFile::copy(src, docLocal));
+    ASSERT_TRUE(QFile::copy(src, docUsb));
+    const QString hash = Database::computeContentHash(docLocal);
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+
+    // 本地阅读状态：展开缩略图（sidebarIndex=1）、自定义宽度 120、
+    // 第 4 页、滚动位置 0.25、书签 {3}
+    ut_insert_operation(m_tester, docLocal, 4, hash, QDateTime::currentMSecsSinceEpoch());
+    QSqlQuery state(m_tester->m_database);
+    state.prepare("UPDATE operation SET sidebarVisible = 1, sidebarIndex = 1, "
+                  "sidebarWidth = 120, sidebarWidthChanged = 1, scrollPosition = 0.25, "
+                  "lastModified = :t WHERE filePath = :p");
+    state.bindValue(":t", QDateTime::currentMSecsSinceEpoch());
+    state.bindValue(":p", docLocal);
+    ASSERT_TRUE(state.exec());
+    ASSERT_TRUE(m_tester->saveBookmarks(docLocal, QSet<int> {3}));
+
+    // U 盘副本首开：自身无记录 → readOperation miss，matchOperationByContent 借用
+    {
+        DocSheet sheetUsb(Dr::FileType::PDF, docUsb, nullptr);
+        EXPECT_FALSE(m_tester->readOperation(&sheetUsb));
+        EXPECT_TRUE(m_tester->matchOperationByContent(QFileInfo(docUsb), &sheetUsb));
+        // 状态与源一致：第 4 页、缩略图面板可见、宽度 120、滚动位置
+        EXPECT_EQ(sheetUsb.m_operation.currentPage, 4);
+        EXPECT_EQ(sheetUsb.m_operation.sidebarVisible, 1);
+        EXPECT_EQ(sheetUsb.m_operation.sidebarIndex, 1);
+        EXPECT_EQ(sheetUsb.m_operation.sidebarWidth, 120);
+        EXPECT_TRUE(sheetUsb.m_operation.sidebarWidthChanged);
+        EXPECT_FLOAT_EQ(sheetUsb.m_operation.scrollPosition, 0.25f);
+        // 源记录未被夺走，借用不新建 operation 记录
+        EXPECT_EQ(ut_operation_count(m_tester, docLocal), 1);
+        EXPECT_EQ(ut_operation_count(m_tester, docUsb), 0);
+        // 书签已复制到新路径（setAlive 后续 readBookmarks 可直接读到），源路径保留
+        QSet<int> borrowed;
+        EXPECT_TRUE(m_tester->readBookmarks(docUsb, borrowed));
+        EXPECT_EQ(borrowed, QSet<int> {3});
+        EXPECT_EQ(ut_bookmark_count(m_tester, docLocal), 1);
+
+        // 模拟关闭落盘：U 盘副本写入自己的记录
+        ASSERT_TRUE(m_tester->saveOperation(&sheetUsb, hash));
+    }
+
+    // 二次打开：读自己的记录（不再借用）；本地后续变化不串扰 U 盘副本
+    QSqlQuery localMove(m_tester->m_database);
+    localMove.prepare("UPDATE operation SET currentPage = 6 WHERE filePath = :p");
+    localMove.bindValue(":p", docLocal);
+    ASSERT_TRUE(localMove.exec());
+    ASSERT_TRUE(m_tester->saveBookmarks(docUsb, QSet<int> {3, 5}));
+    {
+        DocSheet sheetUsb2(Dr::FileType::PDF, docUsb, nullptr);
+        EXPECT_TRUE(m_tester->readOperation(&sheetUsb2));
+        EXPECT_EQ(sheetUsb2.m_operation.currentPage, 4);
+        QSet<int> bms;
+        EXPECT_TRUE(m_tester->readBookmarks(docUsb, bms));
+        EXPECT_EQ(bms, (QSet<int> {3, 5}));
+        EXPECT_EQ(ut_bookmark_count(m_tester, docLocal), 1);
+    }
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+}
+
+TEST_F(TestDatabase, UT_Database_bookmarkForkContentHash_001)
+{
+    // 内容分叉场景（BUG-376029 衍生）：同一文档的两份拷贝，其中一份保存高亮注释后
+    // 内容指纹变化，两份文件的书签都应保留：
+    // - 注释后的文件（新指纹）：书签继续可用
+    // - 原始文件（旧指纹）：书签不被删除，再打开仍可找回
+    // （修复前：saveBookmarks 按路径删除 + readBookmarks 按 stale 清理，旧指纹书签全丢）
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString docLocal = dir + "/fork_local.pdf";
+    const QString docUsb = dir + "/fork_usb.pdf";
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+    ASSERT_TRUE(QFile::copy(src, docLocal));
+    ASSERT_TRUE(QFile::copy(src, docUsb));
+    const QString hash0 = Database::computeContentHash(docLocal);
+    ASSERT_EQ(hash0, Database::computeContentHash(docUsb));
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+
+    // 本地文档加书签
+    ASSERT_TRUE(m_tester->saveBookmarks(docLocal, QSet<int> {0, 2, 4}));
+
+    // 打开U盘文档（内容仍为 hash0）：书签按路径独立，不继承本地路径的书签
+    QSet<int> read;
+    EXPECT_TRUE(m_tester->readBookmarks(docUsb, read));
+    EXPECT_TRUE(read.isEmpty());
+
+    // 在U盘文档上加高亮注释并保存 → 文件内容变化（指纹变为 hash1）
+    {
+        QFile f(docUsb);
+        ASSERT_TRUE(f.open(QIODevice::Append));
+        f.write(QByteArray(2048, 'z'));
+    }
+    const QString hash1 = Database::computeContentHash(docUsb);
+    ASSERT_NE(hash0, hash1);
+
+    // 注释后的文档保存书签：按新指纹全量替换，旧指纹书签不受影响
+    ASSERT_TRUE(m_tester->saveBookmarks(docUsb, QSet<int> {0, 2, 4}));
+
+    // 关键断言 1：注释后的文件（新指纹）书签正常
+    read.clear();
+    EXPECT_TRUE(m_tester->readBookmarks(docUsb, read));
+    EXPECT_EQ(read, (QSet<int> {0, 2, 4}));
+
+    // 关键断言 2：原始文件（旧指纹）书签保留可找回
+    read.clear();
+    EXPECT_TRUE(m_tester->readBookmarks(docLocal, read));
+    EXPECT_EQ(read, (QSet<int> {0, 2, 4}));
+
+    // 新旧指纹的书签记录共存（各一套，互不干扰）
+    QSqlQuery cnt(m_tester->m_database);
+    cnt.prepare("SELECT COUNT(DISTINCT contentHash) FROM bookmark WHERE contentHash IN (:h0, :h1)");
+    cnt.bindValue(":h0", hash0);
+    cnt.bindValue(":h1", hash1);
+    ASSERT_TRUE(cnt.exec());
+    ASSERT_TRUE(cnt.next());
+    EXPECT_EQ(cnt.value(0).toInt(), 2);
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+}
+
+
+TEST_F(TestDatabase, UT_Database_bookmarkPathIndependence_001)
+{
+    // bug 场景：本地与U盘各有一份内容完全相同的文档（hash 相同、路径不同），
+    // 书签曾以内容指纹为唯一关联键跨路径共享：在U盘文档上标记书签并关闭后，
+    // 书签被同步到本地同内容文档上。修复后书签以 路径+指纹 为关联键：
+    // 各路径书签相互独立，互不同步、互不删除。
+    const QString dir = "/tmp/deepin_reader_ut_bookmark";
+    QDir().mkpath(dir);
+    QString src = UTSOURCEDIR;
+    src += "/files/normal.pdf";
+    const QString docLocal = dir + "/indep_local.pdf";
+    const QString docUsb = dir + "/indep_usb.pdf";
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
+    ASSERT_TRUE(QFile::copy(src, docLocal));
+    ASSERT_TRUE(QFile::copy(src, docUsb));
+    ASSERT_EQ(Database::computeContentHash(docLocal), Database::computeContentHash(docUsb));
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+
+    // U盘文档标记书签 {1, 3} 后关闭保存
+    ASSERT_TRUE(m_tester->saveBookmarks(docUsb, QSet<int> {1, 3}));
+
+    // 本地同内容文档打开：不应读到U盘路径的书签
+    QSet<int> read;
+    EXPECT_TRUE(m_tester->readBookmarks(docLocal, read));
+    EXPECT_TRUE(read.isEmpty());
+
+    // 本地文档标记自己的书签 {5} 后关闭保存：U盘书签不受影响
+    ASSERT_TRUE(m_tester->saveBookmarks(docLocal, QSet<int> {5}));
+    read.clear();
+    EXPECT_TRUE(m_tester->readBookmarks(docUsb, read));
+    EXPECT_EQ(read, (QSet<int> {1, 3}));
+
+    // U盘文档清空书签并保存：本地书签不受影响（不被连带删除）
+    ASSERT_TRUE(m_tester->saveBookmarks(docUsb, QSet<int> {}));
+    read.clear();
+    EXPECT_TRUE(m_tester->readBookmarks(docLocal, read));
+    EXPECT_EQ(read, (QSet<int> {5}));
+    EXPECT_EQ(ut_bookmark_count(m_tester, docLocal), 1);
+    EXPECT_EQ(ut_bookmark_count(m_tester, docUsb), 0);
+
+    ut_cleanup_path(m_tester, docLocal);
+    ut_cleanup_path(m_tester, docUsb);
+    QFile::remove(docLocal);
+    QFile::remove(docUsb);
 }


### PR DESCRIPTION
When the same document exists at multiple paths, readOperation may hit a stale record at the new path with a matching contentHash and skip matchOperationByContent, so bookmarks and reading progress stored at the old path are never migrated. Migrating to a path that already has a record also fails with a PRIMARY KEY conflict on operation.filePath.

Fix by merging same-content records from other paths after a verified readOperation hit: union bookmarks (dedup by page, filter mismatched hashes), prefer the state that has bookmarks (else the latest lastOpened), and delete the old-path records. In
matchOperationByContent, exclude the target path itself from candidates and clear its stale record before the path UPDATE.

修复文档移动到已有同内容记录的路径后书签与阅读进度丢失的问题：
readOperation 命中旧记录且指纹校验通过后，合并同内容（docId 或
fileSize+contentHash）的其他路径记录——书签并集迁移（按页去重并
过滤指纹不符的脏书签）、状态择优（带书签记录优先，否则取 lastOpened
较新者）并清理旧路径记录；matchOperationByContent 匹配候选排除目标
路径自身，迁移 UPDATE 前清理目标路径旧记录以避让主键冲突。

Log: 修复文档移动到U盘替换后书签与阅读进度丢失
PMS: BUG-376029
Influence: 本地与U盘存在同名文档时，添加书签后移动/替换文档再打开，书签与阅读进度可正常恢复。

## Summary by Sourcery

Restore document reading state across moves and replacements while keeping independent copies isolated and cleaning up obsolete bookmark data.

Bug Fixes:
- Restore bookmarks and reading progress when documents are moved or replaced at paths that already contain records for the same content.
- Prevent stale or mismatched bookmark data from being applied across replaced files while preserving bookmarks for historical content versions.
- Preserve independent reading state and bookmarks for identical documents that coexist at different paths.

Enhancements:
- Distinguish document moves from copies when matching content, migrating state for vanished sources while borrowing state for existing sources.
- Merge duplicate records by selecting the preferred reading state, migrating valid bookmarks, and removing obsolete path records.
- Improve bookmark lifecycle management, including legacy handling, content-fingerprint association, and orphan cleanup for reliably unavailable local files.
- Avoid saving spurious reading positions while document tabs are hidden and defer layout restoration until the tab is visible.

Tests:
- Add coverage for duplicate-record merging, bookmark migration and deduplication, content-based matching with occupied target paths, copy-state borrowing, path independence, content forks, and orphan bookmark cleanup.