### PR TITLE
fix(reader): save reading progress with 0.5s debounce on page change

### DIFF
--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -121,6 +121,13 @@ DocSheet::DocSheet(const Dr::FileType &fileType, const QString &filePath,  QWidg
     m_autoSaveTimer->setSingleShot(false);
     connect(m_autoSaveTimer, &QTimer::timeout, this, &DocSheet::onAutoSave);
 
+    // 阅读进度防抖保存：页面切换后短延时写入数据库，
+    // 连续翻页/滚动时自动合并，异常退出（如 killall）时进度不丢
+    m_progressSaveTimer = new QTimer(this);
+    m_progressSaveTimer->setInterval(kProgressSaveDebounceMs);
+    m_progressSaveTimer->setSingleShot(true);
+    connect(m_progressSaveTimer, &QTimer::timeout, this, &DocSheet::saveProgressToDb);
+
     qCDebug(appLog) << "DocSheet created end";
 }
 
@@ -1512,6 +1519,10 @@ void DocSheet::onBrowserPageChanged(int page)
         m_operation.currentPage = page;
         if (m_sidebar)
             m_sidebar->setCurrentPage(page);
+
+        // 页面变化后防抖保存阅读进度，异常退出时进度不丢
+        if (m_progressSaveTimer)
+            m_progressSaveTimer->start();
     }
 }
 
@@ -1707,6 +1718,11 @@ void DocSheet::setAlive(bool alive)
         // 停止定时保存
         if (m_autoSaveTimer) {
             m_autoSaveTimer->stop();
+        }
+
+        // 停止阅读进度防抖保存（此处已立即全量保存）
+        if (m_progressSaveTimer) {
+            m_progressSaveTimer->stop();
         }
 
         if (m_documentChanged && m_renderer) {

--- a/reader/uiframe/DocSheet.h
+++ b/reader/uiframe/DocSheet.h
@@ -24,6 +24,10 @@ class QPrinter;
 constexpr int kRestoreScrollDelayMs = 100;
 constexpr int kRestoreCatalogDelayMs = 150;
 
+// 阅读进度防抖落盘延时（毫秒）：页面切换后延时写入数据库，连续翻页/滚动时自动合并，
+// 保证异常退出（如 killall）时阅读进度不丢。防抖时间 0.5s
+constexpr int kProgressSaveDebounceMs = 500;
+
 class PageSearchThread;
 class QTimer;
 struct SheetOperation {
@@ -644,6 +648,7 @@ public:
      * @brief 将当前阅读进度立即写入数据库
      * 更新滚动位置/侧栏状态到 m_operation 并执行 saveOperation。
      * 供书签等已有即时落盘的操作顺带保存进度，异常退出（如 killall）后进度不丢。
+     * 页面切换时由 m_progressSaveTimer 防抖调用（见 kProgressSaveDebounceMs）。
      */
     void saveProgressToDb();
 
@@ -935,6 +940,8 @@ private:
 
     // 定时自动保存
     QTimer *m_autoSaveTimer = nullptr;
+    // 阅读进度防抖保存定时器：页面切换后延时落盘，连续变化自动合并
+    QTimer *m_progressSaveTimer = nullptr;
     // 标记是否从保存状态恢复
     bool m_restoredFromState = false;
     // 标记该 sheet 是否仍需要显示恢复阅读位置提示条


### PR DESCRIPTION
Page changes only updated m_operation.currentPage in memory; progress was persisted only on bookmark/annotation ops, every 30s auto-save or clean close, so killall lost the last page position while bookmarks survived. Start a single-shot debounce timer (500ms, restarted on each page change so bursts coalesce) that calls saveProgressToDb(); the database runs in WAL with synchronous=FULL, so the save survives abnormal termination.

页面切换仅在内存更新当前页，阅读进度此前只在书签/注释操作、30秒自动
保存、正常关闭时落盘，killall 杀进程会丢失最新进度而书签已保存。
新增 0.5 秒防抖定时器（每次页面切换重启计时，连续变化自动合并），
超时后经 saveProgressToDb() 落盘；数据库为 WAL+synchronous=FULL， 异常退出后进度不丢。

Log: 页面切换后防抖保存阅读进度，异常退出进度不丢
PMS: BUG-375997
Influence: 翻页后 0.5 秒自动落盘阅读进度，killall 等异常退出进度可恢复；正常关闭流程行为不变。

## Summary by Sourcery

Persist reading progress after page changes to prevent the latest position from being lost on abnormal exit.

Bug Fixes:
- Persist reading progress shortly after page changes so the latest position survives abnormal process termination.

Enhancements:
- Coalesce rapid page changes with a single-shot debounce while preserving immediate saves during normal shutdown.