### PR TITLE
fix(reader): anchor progress restore to saved page

### DIFF
--- a/reader/browser/SheetBrowser.cpp
+++ b/reader/browser/SheetBrowser.cpp
@@ -1105,6 +1105,9 @@ void SheetBrowser::deform(SheetOperation &operation)
 
     beginViewportChange();
     qCDebug(appLog) << "SheetBrowser::deform() - Begin viewport change";
+
+    // 布局重建完成，通知外层（阅读位置恢复守卫据此判断布局稳定时机）
+    emit sigDeformed();
 }
 
 bool SheetBrowser::hasLoaded()

--- a/reader/browser/SheetBrowser.h
+++ b/reader/browser/SheetBrowser.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -363,6 +363,11 @@ public:
 
 signals:
     void sigPageChanged(int page);
+
+    /**
+     * @brief 布局重建完成（deform 返回后发出），供阅读位置恢复守卫判断布局稳定时机
+     */
+    void sigDeformed();
 
     void sigNeedPageFirst();
 

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -94,6 +94,7 @@ DocSheet::DocSheet(const Dr::FileType &fileType, const QString &filePath,  QWidg
     m_sidebar->setMinimumWidth(266);
 
     connect(m_browser, SIGNAL(sigPageChanged(int)), this, SLOT(onBrowserPageChanged(int)));
+    connect(m_browser, &SheetBrowser::sigDeformed, this, &DocSheet::onBrowserDeformed);
     connect(m_browser, SIGNAL(sigNeedPagePrev()), this, SLOT(onBrowserPagePrev()));
     connect(m_browser, SIGNAL(sigNeedPageNext()), this, SLOT(onBrowserPageNext()));
     connect(m_browser, SIGNAL(sigNeedPageFirst()), this, SLOT(onBrowserPageFirst()));
@@ -127,6 +128,12 @@ DocSheet::DocSheet(const Dr::FileType &fileType, const QString &filePath,  QWidg
     m_progressSaveTimer->setInterval(kProgressSaveDebounceMs);
     m_progressSaveTimer->setSingleShot(true);
     connect(m_progressSaveTimer, &QTimer::timeout, this, &DocSheet::saveProgressToDb);
+
+    // 阅读位置恢复稳定计时器：布局连续无变化后执行最终恢复（见 beginRestoreGuard）
+    m_restoreSettleTimer = new QTimer(this);
+    m_restoreSettleTimer->setInterval(kRestoreSettleMs);
+    m_restoreSettleTimer->setSingleShot(true);
+    connect(m_restoreSettleTimer, &QTimer::timeout, this, &DocSheet::onLayoutSettled);
 
     qCDebug(appLog) << "DocSheet created end";
 }
@@ -1327,21 +1334,9 @@ void DocSheet::onOpened(deepin_reader::Document::Error error)
                         << "sidebarW=" << m_operation.sidebarWidth << "changed=" << m_operation.sidebarWidthChanged
                         << "sidebarVisible=" << m_operation.sidebarVisible << "scaleMode=" << m_operation.scaleMode;
 
-        // 恢复滚动位置
+        // 恢复阅读位置：守卫期间以保存页码为锚，布局稳定后执行精细比例恢复并校验页码
         if (m_restoredFromState && m_operation.scrollPosition > 0.0f) {
-            qCDebug(appLog) << "onOpened scheduling restoreScrollPosition +" << kRestoreScrollDelayMs << "ms";
-            // 延迟恢复滚动位置（等 deform 和布局完成后）
-            QTimer::singleShot(kRestoreScrollDelayMs, this, [this]() {
-                qCDebug(appLog) << "onOpened restore timer FIRE currentPage=" << m_operation.currentPage
-                                 << "scrollPos=" << m_operation.scrollPosition;
-                m_browser->restoreScrollPosition(m_operation.scrollPosition);
-                qCDebug(appLog) << "onOpened after restoreScrollPosition currentPage=" << m_operation.currentPage
-                                 << "browserCurPage=" << m_browser->currentPage();
-                // 显示恢复提示条
-                m_needsRestoreTip = true;
-                emit sigShowRestoreTip(this);
-                emit sigStateRestored(this);
-            });
+            beginRestoreGuard(true);
         }
 
         m_sidebar->handleOpenSuccess();
@@ -1515,6 +1510,12 @@ void DocSheet::onBrowserPageChanged(int page)
 {
     qCDebug(appLog) << "onBrowserPageChanged" << page << "prev currentPage=" << m_operation.currentPage;
     qCDebug(appLog) << "onBrowserPageChanged";
+    // 阅读位置恢复守卫期间（布局未稳定）：页码以保存值为锚，
+    // 不回写操作记录、不触发进度落盘，避免比例恢复跨页污染页码
+    if (m_restoreGuardActive) {
+        qCInfo(appLog) << "onBrowserPageChanged ignored during restore guard, anchorPage=" << m_restoreAnchorPage;
+        return;
+    }
     if (m_operation.currentPage != page) {
         m_operation.currentPage = page;
         if (m_sidebar)
@@ -1725,6 +1726,12 @@ void DocSheet::setAlive(bool alive)
             m_progressSaveTimer->stop();
         }
 
+        // 停止阅读位置恢复守卫（关闭时无需再恢复，页码保持锚点值落盘）
+        if (m_restoreSettleTimer) {
+            m_restoreSettleTimer->stop();
+        }
+        m_restoreGuardActive = false;
+
         if (m_documentChanged && m_renderer) {
             if (m_renderer->save()) {
                 m_documentChanged = false;
@@ -1868,11 +1875,55 @@ void DocSheet::restoreSavedViewState()
         });
     }
 
-    // 恢复滚动位置
+    // 恢复滚动位置（守卫期间若因侧栏宽度恢复等再触发 deform，最终恢复推迟到布局稳定后）
+    // 标签页回切不弹恢复提示条，显隐由 sigCurSheetChanged 按 needsRestoreTip 同步
     if (m_browser && m_operation.scrollPosition > 0.0f) {
-        QTimer::singleShot(kRestoreScrollDelayMs, this, [this]() {
-            m_browser->restoreScrollPosition(m_operation.scrollPosition);
-        });
+        beginRestoreGuard(false);
+    }
+}
+
+void DocSheet::beginRestoreGuard(bool notifyTip)
+{
+    m_restoreGuardActive = true;
+    m_restoreNotifyTip = notifyTip;
+    m_restoreAnchorPage = qBound(1, m_operation.currentPage, qMax(1, pageCount()));
+    m_restoreSettleTimer->start(kRestoreSettleMs);
+    qCInfo(appLog) << "beginRestoreGuard anchorPage=" << m_restoreAnchorPage
+                    << "scrollPos=" << m_operation.scrollPosition << "notifyTip=" << notifyTip;
+}
+
+void DocSheet::onBrowserDeformed()
+{
+    // 守卫期间布局仍在变化（缩放/窗口/侧栏），推迟最终恢复，稳定后再执行
+    if (m_restoreGuardActive)
+        m_restoreSettleTimer->start(kRestoreSettleMs);
+}
+
+void DocSheet::onLayoutSettled()
+{
+    if (!m_restoreGuardActive)
+        return;
+    m_restoreGuardActive = false;
+
+    if (m_browser && opened() && m_operation.scrollPosition > 0.0f) {
+        // 布局稳定后做精细恢复；比例受缩放/视口影响可能跨页，
+        // 恢复出的页码与锚点不一致时以保存页码为准（页级正确性优先）
+        m_browser->restoreScrollPosition(m_operation.scrollPosition);
+        int restoredPage = m_browser->currentPage();
+        if (restoredPage != m_restoreAnchorPage) {
+            qCInfo(appLog) << "onLayoutSettled ratio drifted page=" << restoredPage
+                            << "-> fallback to anchor page" << m_restoreAnchorPage;
+            m_browser->setCurrentPage(m_restoreAnchorPage);
+        }
+        qCInfo(appLog) << "onLayoutSettled final page=" << m_browser->currentPage()
+                        << "scrollPos=" << m_operation.scrollPosition;
+    }
+
+    if (m_restoreNotifyTip) {
+        m_restoreNotifyTip = false;
+        m_needsRestoreTip = true;
+        emit sigShowRestoreTip(this);
+        emit sigStateRestored(this);
     }
 }
 

--- a/reader/uiframe/DocSheet.h
+++ b/reader/uiframe/DocSheet.h
@@ -21,8 +21,13 @@ class EncryptionPage;
 class QPropertyAnimation;
 class QPrinter;
 
-constexpr int kRestoreScrollDelayMs = 100;
 constexpr int kRestoreCatalogDelayMs = 150;
+
+// 阅读位置恢复的布局稳定窗口（毫秒）：守卫期间以保存页码为锚，deform 每次都回到锚点页；
+// 布局连续该时长无变化后视为稳定，再执行精细比例恢复并校验页码。
+// 启动阶段 fit-width 缩放会随窗口/侧栏宽度变化多次重算，若立即用整篇比例换算绝对位置，
+// 会在中间态布局上跨页，页码被污染后后续 deform 还会滚到错误页顶并落盘（进度"跳回上一页"）
+constexpr int kRestoreSettleMs = 400;
 
 // 阅读进度防抖落盘延时（毫秒）：页面切换后延时写入数据库，连续翻页/滚动时自动合并，
 // 保证异常退出（如 killall）时阅读进度不丢。防抖时间 0.5s
@@ -671,6 +676,17 @@ public:
     void restoreSavedViewState();
 
     /**
+     * @brief 开始阅读位置恢复守卫
+     * 以 m_operation.currentPage 为锚点：守卫期间页码信号不回写操作记录、不触发进度落盘，
+     * deform 重布局时自动回到锚点页；布局连续 kRestoreSettleMs 无变化后
+     * 在 onLayoutSettled 中执行精细比例恢复并校验页码，最后解除守卫。
+     * @param notifyTip 是否在恢复完成后发出恢复提示（仅打开文档的首次恢复为 true；
+     *                  标签页回切不弹条，显隐由 sigCurSheetChanged 按 needsRestoreTip 同步，
+     *                  避免用户已关闭的提示条再次弹出）
+     */
+    void beginRestoreGuard(bool notifyTip);
+
+    /**
      * @brief 获取当前滚动位置（0.0~1.0）
      */
     float currentScrollPosition() const;
@@ -713,6 +729,17 @@ private:
      * @brief 重置sidebar,browser的parent
      */
     void resetChildParent();
+
+    /**
+     * @brief 守卫期间浏览器 deform 后重等布局稳定（见 beginRestoreGuard）
+     */
+    void onBrowserDeformed();
+
+    /**
+     * @brief 布局稳定后的最终恢复：精细比例恢复+页码校验回退锚点，
+     * 解除守卫并发出恢复提示（见 beginRestoreGuard）
+     */
+    void onLayoutSettled();
 
 public slots:
     /**
@@ -944,6 +971,14 @@ private:
     QTimer *m_progressSaveTimer = nullptr;
     // 标记是否从保存状态恢复
     bool m_restoredFromState = false;
+    // 阅读位置恢复守卫：布局未稳定期间页码以保存值为锚，防止比例恢复跨页污染页码
+    bool m_restoreGuardActive = false;
+    // 恢复守卫的锚点页（保存的当前页）
+    int m_restoreAnchorPage = 1;
+    // 本次守卫完成后是否允许发出恢复提示（仅打开文档的首次恢复）
+    bool m_restoreNotifyTip = false;
+    // 布局稳定计时器：连续 kRestoreSettleMs 无 deform 后执行最终恢复
+    QTimer *m_restoreSettleTimer = nullptr;
     // 标记该 sheet 是否仍需要显示恢复阅读位置提示条
     // 用户点击"跳转到首页"后置为 false，切换 tab 时据此决定是否显示提示条
     bool m_needsRestoreTip = false;


### PR DESCRIPTION
Restore of reading progress could regress one page because the saved whole-document ratio was converted with a mid-startup layout while fit-width scale was still changing; the drifted page was then written back and pinned by later deform runs.

Guard the restore with the saved page as anchor: page updates are ignored until layout stays unchanged for 400ms, then the fine-grained ratio is re-applied and falls back to the saved page when it drifts.

阅读进度恢复可能回退一页：fit-width 缩放启动期仍在变化，整篇比例
按中间态布局换算的绝对位置跨页，页码被污染后又被后续 deform 固化
并落盘。

恢复期以保存页码为锚：布局连续 400ms 无变化前忽略页码回写，稳定
后执行精细恢复，跨页时回退锚点页。

Log: 修复重开文档时阅读进度回退到上一页的问题
PMS: BUG-376081
Influence: 文档查看器阅读进度恢复逻辑，恢复不再受启动布局变化影响。

## Summary by Sourcery

Anchor reading-progress restoration to the saved page until the document layout stabilizes, then validate the final position to prevent page regressions.

Bug Fixes:
- Prevent reading-progress restoration from reverting to the wrong page when startup layout changes affect position calculations.

Enhancements:
- Stabilize layout before applying fine-grained progress restoration, preserve the saved page as an anchor during recovery, and fall back to it if the restored ratio crosses page boundaries.