### PR TITLE
fix(reader): close FindWidget on tab switch to prevent cross-document…

### DIFF
--- a/reader/browser/SheetBrowser.cpp
+++ b/reader/browser/SheetBrowser.cpp
@@ -2062,6 +2062,16 @@ void SheetBrowser::jumpToPrevSearchResult()
     }
 }
 
+void SheetBrowser::hideFindWidget()
+{
+    qCDebug(appLog) << "hideFindWidget";
+    if (!m_findWidget.isNull()) {
+        m_findWidget->hide();
+        m_findWidget->deleteLater();
+        m_findWidget = nullptr;
+    }
+}
+
 void SheetBrowser::handleSearchStart()
 {
     qCDebug(appLog) << "SheetBrowser::handleSearchStart() - Handling search start";

--- a/reader/browser/SheetBrowser.h
+++ b/reader/browser/SheetBrowser.h
@@ -279,6 +279,12 @@ public:
     void handlePrepareSearch();
 
     /**
+     * @brief hideFindWidget
+     * 隐藏并销毁搜索框,切换标签页时调用,防止搜索串档
+     */
+    void hideFindWidget();
+
+    /**
      * @brief jumpToNextSearchResult
      * 跳到下一个搜索条目中
      */

--- a/reader/uiframe/CentralDocPage.cpp
+++ b/reader/uiframe/CentralDocPage.cpp
@@ -321,6 +321,8 @@ void CentralDocPage::onTabChanged(DocSheet *sheet)
         // 离开当前 sheet 前，保存其阅读状态
         QPointer<DocSheet> prevSheet = qobject_cast<DocSheet *>(m_stackedLayout->currentWidget());
         if (prevSheet && prevSheet != sheet && prevSheet->opened()) {
+            // 关闭前一个 sheet 的搜索框,防止切换标签后搜索串档
+            prevSheet->closeFindWidget();
             prevSheet->saveCurrentViewState();
         }
 

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -1598,6 +1598,14 @@ void DocSheet::jumpToPrevSearchResult()
     m_browser->jumpToPrevSearchResult();
 }
 
+void DocSheet::closeFindWidget()
+{
+    qCDebug(appLog) << "closeFindWidget";
+    stopSearch();
+    if (m_browser)
+        m_browser->hideFindWidget();
+}
+
 void DocSheet::stopSearch()
 {
     qCDebug(appLog) << "stopSearch";

--- a/reader/uiframe/DocSheet.h
+++ b/reader/uiframe/DocSheet.h
@@ -608,6 +608,12 @@ public:
     void jumpToPrevSearchResult();
 
     /**
+     * @brief closeFindWidget
+     * 关闭搜索框并停止搜索,切换标签页时调用
+     */
+    void closeFindWidget();
+
+    /**
      * @brief showEncryPage
      * 显示解锁页面
      */


### PR DESCRIPTION
… search

When switching between document tabs, the FindWidget (whose parent is the MainWindow, not the SheetBrowser) remained visible with its m_docSheet pointer still bound to the previous document. Searching from this stale widget executed the search on the wrong document.

Add SheetBrowser::hideFindWidget() to hide and destroy the FindWidget, DocSheet::closeFindWidget() to stop the search and hide the widget, and call prevSheet->closeFindWidget() in CentralDocPage::onTabChanged() before switching to the new tab.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-376317.html

## Summary by Sourcery

Prevent cross-document searches by closing the previous document’s FindWidget before switching tabs.

Bug Fixes:
- Close and destroy the active document’s FindWidget when switching tabs to prevent searches from targeting the previous document.

Enhancements:
- Centralize search cleanup across DocSheet and SheetBrowser during document tab changes.