### PR TITLE
fix(reader): close FindWidget on tab switch to prevent cross-document…

### DIFF
--- a/reader/browser/SheetBrowser.cpp
+++ b/reader/browser/SheetBrowser.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1732,6 +1731,15 @@ void SheetBrowser::jumpToPrevSearchResult()
                 index = -1;
             }
         }
+    }
+}
+
+void SheetBrowser::hideFindWidget()
+{
+    if (!m_findWidget.isNull()) {
+        m_findWidget->hide();
+        m_findWidget->deleteLater();
+        m_findWidget = nullptr;
     }
 }
 

--- a/reader/browser/SheetBrowser.h
+++ b/reader/browser/SheetBrowser.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -261,6 +260,12 @@ public:
      * 搜索操作,弹出搜索框
      */
     void handlePrepareSearch();
+
+    /**
+     * @brief hideFindWidget
+     * 隐藏并销毁搜索框,切换标签页时调用,防止搜索串档
+     */
+    void hideFindWidget();
 
     /**
      * @brief jumpToNextSearchResult

--- a/reader/uiframe/CentralDocPage.cpp
+++ b/reader/uiframe/CentralDocPage.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -275,6 +274,11 @@ void CentralDocPage::onOpened(DocSheet *sheet, deepin_reader::Document::Error er
 void CentralDocPage::onTabChanged(DocSheet *sheet)
 {
     if (nullptr != sheet) {
+        // 关闭前一个 sheet 的搜索框,防止切换标签后搜索串档
+        QPointer<DocSheet> prevSheet = qobject_cast<DocSheet *>(m_stackedLayout->currentWidget());
+        if (prevSheet && prevSheet != sheet && prevSheet->opened()) {
+            prevSheet->closeFindWidget();
+        }
         m_stackedLayout->setCurrentWidget(sheet);
 
         sheet->defaultFocus();

--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1127,6 +1126,13 @@ void DocSheet::jumpToPrevSearchResult()
 {
     //m_sidebar->jumpToPrevSearchResult();  //左侧应该同时跳转，目前无此需求
     m_browser->jumpToPrevSearchResult();
+}
+
+void DocSheet::closeFindWidget()
+{
+    stopSearch();
+    if (m_browser)
+        m_browser->hideFindWidget();
 }
 
 void DocSheet::stopSearch()

--- a/reader/uiframe/DocSheet.h
+++ b/reader/uiframe/DocSheet.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -575,6 +574,12 @@ public:
      * 跳转上一个搜索结果
      */
     void jumpToPrevSearchResult();
+
+    /**
+     * @brief closeFindWidget
+     * 关闭搜索框并停止搜索,切换标签页时调用
+     */
+    void closeFindWidget();
 
     /**
      * @brief showEncryPage


### PR DESCRIPTION
… search

When switching between document tabs, the FindWidget (whose parent is the MainWindow, not the SheetBrowser) remained visible with its m_docSheet pointer still bound to the previous document. Searching from this stale widget executed the search on the wrong document.

Add SheetBrowser::hideFindWidget() to hide and destroy the FindWidget, DocSheet::closeFindWidget() to stop the search and hide the widget, and call prevSheet->closeFindWidget() in CentralDocPage::onTabChanged() before switching to the new tab.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-376317.html

## Summary by Sourcery

Prevent cross-document searches by closing the previous document's search widget before activating a new tab.

Bug Fixes:
- Close and destroy the active document's FindWidget when switching tabs to prevent searches from being executed against the previously selected document.

Enhancements:
- Centralize FindWidget shutdown by stopping its search before removing the widget during document transitions.