### PR TITLE
fix(reader): fix render thread quit race and adapt page-change unit test

### DIFF
--- a/reader/browser/PageRenderThread.cpp
+++ b/reader/browser/PageRenderThread.cpp
@@ -314,7 +314,9 @@ void PageRenderThread::appendTask(DocCloseTask task)
 
 void PageRenderThread::run()
 {
-    m_quit = false;
+    // 注意: 不能在这里重置 m_quit。若 destroyForever() 在线程进入 run() 前
+    // 已置 m_quit=true, 此处重置会吞掉退出请求,导致 wait() 永久阻塞。
+    // 实例创建时 m_quit 默认即为 false, 无需重复初始化。
     qCDebug(appLog) << "====开始执行任务====";
 
     while (!m_quit) {

--- a/reader/browser/PageRenderThread.h
+++ b/reader/browser/PageRenderThread.h
@@ -11,6 +11,7 @@
 
 #include <QThread>
 #include <QMutex>
+#include <atomic>
 #include <QStack>
 #include <QImage>
 
@@ -283,7 +284,8 @@ private:
     QMutex m_closeMutex;
     QList<DocCloseTask> m_closeTasks;
 
-    bool m_quit = false;
+    // 原子量: 主线程 destroyForever 写、渲染线程读, 避免数据竞争
+    std::atomic<bool> m_quit {false};
 
     static bool s_quitForever;
 

--- a/tests/uiframe/ut_docsheet.cpp
+++ b/tests/uiframe/ut_docsheet.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1283,6 +1283,14 @@ TEST_F(TestDocSheet, UT_DocSheet_docBasicInfo_001)
 
 TEST_F(TestDocSheet, UT_DocSheet_onBrowserPageChanged_001)
 {
+    // onBrowserPageChanged 在浏览器不可见时会忽略页码回写（防进度污染守卫）,
+    // 单测环境不 show 窗口, isVisible 恒为 false, 需打桩绕过;
+    // 同时桩掉 sidebar 的 setCurrentPage, 避免触发缩略图渲染任务导致
+    // PageRenderThread 在进程退出阶段 start/wait 竞争挂死
+    Stub s;
+    s.set(ADDR(QWidget, isVisible), isVisible_stub_true);
+    s.set(ADDR(SheetSidebar, setCurrentPage), setCurrentPage_stub);
+
     m_tester->m_operation.currentPage = 2;
     m_tester->onBrowserPageChanged(1);
     EXPECT_TRUE(m_tester->m_operation.currentPage == 1);


### PR DESCRIPTION
## 问题 / Problem

1. **进程退出挂死**: `PageRenderThread::destroyForever()` 在线程进入 `run()` 前设置 `m_quit = true`，会被 `run()` 第一行的 `m_quit = false` 无条件覆盖，导致 `wait()` 永久阻塞（应用退出时恰好存在文档关闭任务即可触发；单测环境高概率复现）。
2. **单测失败**: `f15ae39c` 为 `DocSheet::onBrowserPageChanged` 新增了可见性守卫，离屏单测环境中 `m_browser->isVisible()` 恒为 false，页码不回写，`UT_DocSheet_onBrowserPageChanged_001` 断言失败。

## 修复 / Fix

- `PageRenderThread::run()` 不再无条件重置 `m_quit`（实例创建时默认即为 false），避免吞掉退出请求
- `m_quit` 改为 `std::atomic<bool>`，消除跨线程读写数据竞争
- 单测补 `isVisible` 与 `SheetSidebar::setCurrentPage` 桩，适配新守卫并避免单测触发渲染线程

## 自测 / Test

- `TestDocSheet.UT_DocSheet_onBrowserPageChanged_001` 单跑通过且进程正常退出（修复前挂死）
- 全量套件 1120/1120 通过，`failures="0"`

## Summary by Sourcery

Fix the render-thread shutdown race and adapt page-change testing to the browser visibility guard.

Bug Fixes:
- Prevent render-thread shutdown hangs by preserving early quit requests and making the quit state safe for cross-thread access.

Tests:
- Update the page-change unit test to account for visibility guarding and avoid starting rendering work during the test.