### PR TITLE
fix(reader): keep restore-tip notify flag on tab switch during startup restore

### DIFF
--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -1892,7 +1892,11 @@ void DocSheet::restoreSavedViewState()
     // 恢复滚动位置（守卫期间若因侧栏宽度恢复等再触发 deform，最终恢复推迟到布局稳定后）
     // 标签页回切不弹恢复提示条，显隐由 sigCurSheetChanged 按 needsRestoreTip 同步
     if (m_browser && m_operation.scrollPosition > 0.0f) {
-        beginRestoreGuard(false);
+        if (m_restoreGuardActive) {
+            m_restoreSettleTimer->start(kRestoreSettleMs);
+        } else {
+            beginRestoreGuard(false);
+        }
     }
 }
 


### PR DESCRIPTION
## 问题

BUG-376441：打开多个文档并滚动产生阅读进度后关闭文档查看器，再次打开时只有一个文档显示"已恢复到上次阅读位置"提示条，其余标签页永不显示。

## 根因

启动期多文档恢复时，非可见页签的恢复守卫（`beginRestoreGuard(true)`）在 `onLayoutSettled` 中因页签不可见被顺延，`m_restoreNotifyTip=true` 处于待消费状态。用户首次切到该页签时，`CentralDocPage::onTabChanged` → `DocSheet::restoreSavedViewState()` 无条件调用 `beginRestoreGuard(false)`，把待消费的通知标志覆盖为 false。随后恢复流程正常完成，但 `m_needsRestoreTip` 永不置位，标签切换时提示条显隐分支永远判 false。

只有启动时恰好可见的活跃标签（上次会话的活跃文档）能在覆盖发生前完成恢复并弹条，与 bug 现象完全吻合。

## 修复

`restoreSavedViewState()` 中，若恢复守卫已激活（顺延中的首次恢复），保留其弹条通知标志，仅重启稳定计时等待布局对齐；守卫未激活时保持原有"回切不弹条"行为。

修复后每个有阅读进度的标签页首次切换过去时会恢复滚动位置并弹出提示条；关闭提示条/跳转首页后不再打扰（原有行为不变）。

## 验证

- 增量编译通过（deepin-reader 与 test-deepin-reader 目标）。
- 详细分析见 `.pms/bugs/376441/analysis-report.md`。

PMS: BUG-376441

## Summary by Sourcery

Bug Fixes:
- Preserve pending restore notifications when switching to tabs during startup document restoration, ensuring each restored document can display its reading-position notification.