### PR TITLE
fix(test): connect sheet destroyed signal to prevent singleton segfault

### DIFF
--- a/tests/sidebar/ut_readerimagethreadpoolmanager.cpp
+++ b/tests/sidebar/ut_readerimagethreadpoolmanager.cpp
@@ -169,6 +169,8 @@ TEST_F(UT_ReaderImageThreadPoolManager, UT_onTaskFinished)
     param.receiver = new QObject();
     param.slotFun = "dummySlot";
 
+    QObject::connect(sheet, &QObject::destroyed, m_tester, &ReaderImageThreadPoolManager::onDocProxyDestroyed);
+
     QImage img(10, 10, QImage::Format_ARGB32);
     m_tester->onTaskFinished(param, img);
 
@@ -192,6 +194,8 @@ TEST_F(UT_ReaderImageThreadPoolManager, UT_addgetDocImageTask)
     param.sheet = sheet;
     param.receiver = receiver;
     param.slotFun = "dummySlot";
+
+    QObject::connect(sheet, &QObject::destroyed, m_tester, &ReaderImageThreadPoolManager::onDocProxyDestroyed);
 
     m_tester->addgetDocImageTask(param);
 


### PR DESCRIPTION
## 问题

`test-deepin-reader` 在运行完最后一个用例 `UT_ReaderImageThreadPoolManager.UT_addgetDocImageTask` 后，进程退出阶段发生段错误（SIGSEGV，exit code 255）。

## 根因

`UT_onTaskFinished` 和 `UT_addgetDocImageTask` 两个用例创建了 `DocSheet` 对象并注册到 `ReaderImageThreadPoolManager` 单例中，但在删除 sheet 时未连接 `destroyed` 信号到 `onDocProxyDestroyed` 槽进行清理（同文件中 `UT_setImageForDocSheet` 有此连接且正常通过）。

sheet 被 `delete` 后，单例内部仍持有悬空指针，进程退出时单例析构访问这些悬空指针 → 段错误。

## 修复

在 `UT_onTaskFinished` 和 `UT_addgetDocImageTask` 中，于调用 `onTaskFinished` / `addgetDocImageTask` 之前添加：

```cpp
QObject::connect(sheet, &QObject::destroyed, m_tester, &ReaderImageThreadPoolManager::onDocProxyDestroyed);
```

与 `UT_setImageForDocSheet` 保持一致，确保 sheet 销毁时单例正确清理内部引用。

## 验证

- 全量 1120 个用例全部通过，exit code = 0（修复前 exit code = 255）
- `UT_ReaderImageThreadPoolManager` 全部 9 个用例通过

## 变更文件

- `tests/sidebar/ut_readerimagethreadpoolmanager.cpp`（+4 行）

## Summary by Sourcery

Prevent dangling document-sheet references from causing singleton teardown segmentation faults in image thread pool manager tests.

Bug Fixes:
- Prevent test-process crashes during shutdown by ensuring destroyed document sheets are removed from the image thread pool manager's tracking state.

Tests:
- Update image thread pool manager tests to clean up sheet registrations when test objects are destroyed.