### PR TITLE
fix(reader): skip docx annotation auto-save so close prompts save-as …

### DIFF
--- a/reader/uiframe/DocSheet.cpp
+++ b/reader/uiframe/DocSheet.cpp
@@ -2166,9 +2166,14 @@ void DocSheet::onAutoSave()
     qCDebug(appLog) << "Auto-save triggered for:" << m_filePath;
 
     // 先保存文档注释（高亮、文本标注等），防止异常退出时注释丢失；
-    // 保存会改变文件内容，之后的指纹/哈希计算必须基于最新内容
+    // 保存会改变文件内容，之后的指纹/哈希计算必须基于最新内容。
+    // docx 为转换打开格式，注释只能写入临时目录中的转换产物 temp.pdf，
+    // 自动保存无法真正持久化；若此处照常保存并清掉脏标志，关闭时会因
+    // fileChanged() 为假而跳过保存确认框，注释随临时目录删除而静默丢失
+    // （BUG-376501）。故 docx 保持未保存状态，由关闭时的确认框引导
+    // 用户另存为 PDF 完成持久化。
     bool contentSaved = false;
-    if (m_documentChanged) {
+    if (m_documentChanged && Dr::DOCX != fileType()) {
         if (m_renderer && m_renderer->save()) {
             m_documentChanged = false;
             m_sidebar->changeResetModelData();


### PR DESCRIPTION
…dialog

Docx files are opened through a converted temp.pdf under a random temporary directory, so annotation auto-save cannot really persist: onAutoSave wrote annotations into temp.pdf and cleared the changed flag, which made fileChanged() false on close. The save-confirmation dialog was therefore skipped and annotations were silently lost when the temporary directory was removed.

Skip the annotation save in onAutoSave for docx and keep the sheet marked as changed, so closing prompts the confirmation dialog where "Save" routes to save-as PDF. PDF/DJVU/XPS behavior is unchanged.

Log: 修复 docx 添加注释后关闭查看器不弹保存确认框导致注释静默丢失的问题
PMS: BUG-376501
Influence: docx 添加注释/高亮后关闭查看器会弹保存确认框，选"保存"可另存为 PDF 保留注释；PDF/DJVU/XPS 的自动保存行为不变。

## Summary by Sourcery

Ensure DOCX annotation changes prompt for confirmation on close, allowing users to save them as PDF.

Bug Fixes:
- Preserve the changed state for annotations added to DOCX files so closing the viewer displays the save-confirmation dialog instead of silently losing them.
- Keep existing annotation auto-save behavior unchanged for PDF, DJVU, and XPS files.