### PR TITLE
fix(test): adapt night mode tests to async NightFilter refactor

### DIFF
--- a/tests/browser/ut_browserpage.cpp
+++ b/tests/browser/ut_browserpage.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "BrowserPage.h"
+#include "NightFilter.h"
 #include "PageRenderThread.h"
 #include "BrowserAnnotation.h"
 #include "PDFModel.h"
@@ -837,11 +838,30 @@ TEST_F(TestBrowserPage, UT_BrowserPage_isBigDoc_001)
 
 TEST_F(TestBrowserPage, UT_BrowserPage_applyNightMode_001)
 {
-    QPixmap nullPix;
-    EXPECT_TRUE(m_tester->applyNightMode(nullPix).isNull());
+    // applyNightMode 已重构为异步实现(NightFilter + 后台线程),
+    // 此处直接测试 NightFilter::apply 纯滤镜逻辑的输入/输出断言
 
-    QPixmap src(16, 16);
-    src.fill(Qt::white);
-    QPixmap dst = m_tester->applyNightMode(src);
-    EXPECT_FALSE(dst.isNull());
+    // 空图像输入返回空图像
+    QImage nullImg;
+    EXPECT_TRUE(NightFilter::apply(nullImg).isNull());
+
+    // 白色图像经夜间滤镜反色后应为深色背景
+    QImage whiteImg(16, 16, QImage::Format_ARGB32);
+    whiteImg.fill(Qt::white);
+    QImage nightImg = NightFilter::apply(whiteImg);
+    EXPECT_FALSE(nightImg.isNull());
+    QRgb pixel = nightImg.pixel(0, 0);
+    EXPECT_LT(qRed(pixel), 128);
+    EXPECT_LT(qGreen(pixel), 128);
+    EXPECT_LT(qBlue(pixel), 128);
+
+    // 深色像素(boostSourceBelow 以下)反色后应提纯白
+    QImage darkImg(16, 16, QImage::Format_ARGB32);
+    darkImg.fill(Qt::black);
+    QImage darkNight = NightFilter::apply(darkImg);
+    EXPECT_FALSE(darkNight.isNull());
+    QRgb darkPixel = darkNight.pixel(0, 0);
+    EXPECT_EQ(qRed(darkPixel), 255);
+    EXPECT_EQ(qGreen(darkPixel), 255);
+    EXPECT_EQ(qBlue(darkPixel), 255);
 }

--- a/tests/browser/ut_pagerenderthread.cpp
+++ b/tests/browser/ut_pagerenderthread.cpp
@@ -65,6 +65,13 @@ static void handleRenderFinished_stub(const int &, const QPixmap &, const QRect 
     g_funcName = __FUNCTION__;
 }
 
+// setImageObjectRects stub: night mode refactoring added this call before
+// handleRenderFinished in onDocPageNormalImageTaskFinished / onDocPageBigImageTaskFinished.
+// Stub prevents null-pointer dereference when task.page is nullptr.
+static void setImageObjectRects_stub(const QVector<QRectF> &, int, int)
+{
+}
+
 static void handleWordLoaded_stub(const QList<deepin_reader::Word> &)
 {
     g_funcName = __FUNCTION__;
@@ -228,6 +235,7 @@ TEST_F(TestPageRenderThread, UT_PageRenderThread_onDocPageNormalImageTaskFinishe
     Stub s;
     s.set(ADDR(DocSheet, existSheet), existSheet_true_stub);
     s.set(ADDR(BrowserPage, handleRenderFinished), handleRenderFinished_stub);
+    s.set(ADDR(BrowserPage, setImageObjectRects), setImageObjectRects_stub);
 
     DocPageNormalImageTask task;
     task.sheet = nullptr;   // existSheet is stubbed to return true anyway
@@ -263,6 +271,7 @@ TEST_F(TestPageRenderThread, UT_PageRenderThread_onDocPageBigImageTaskFinished_0
     Stub s;
     s.set(ADDR(DocSheet, existSheet), existSheet_true_stub);
     s.set(ADDR(BrowserPage, handleRenderFinished), handleRenderFinished_stub);
+    s.set(ADDR(BrowserPage, setImageObjectRects), setImageObjectRects_stub);
 
     DocPageBigImageTask task;
     task.sheet = nullptr;


### PR DESCRIPTION
## Summary

Night mode was refactored to an async implementation (`EyeProtectionManager` + `NightFilter` + background thread), removing `BrowserPage::applyNightMode`. The existing tests still called the removed API, causing compile failure and preventing the entire test suite from running.

## Changes

**`tests/browser/ut_browserpage.cpp`** — `UT_BrowserPage_applyNightMode_001`:
- Rewrote to test `NightFilter::apply()` pure filter logic directly (null input → null output; white image → dark inverted output; dark image → boosted white) instead of the removed synchronous `applyNightMode` method.

**`tests/browser/ut_pagerenderthread.cpp`** — `onDocPageNormalImageTaskFinished_002` / `onDocPageBigImageTaskFinished_002`:
- Added `setImageObjectRects` stub. The refactoring inserted `task.page->setImageObjectRects()` before `handleRenderFinished()` in these slots; without the stub, the null `task.page` caused a segfault that killed the test process, preventing `.gcda` coverage generation.

## Test Results

```
[==========] 1120 tests from 77 test suites ran. (50330 ms total)
[  PASSED  ] 1120 tests.
```

- Line coverage: 83.80%
- Function coverage: 98.50%

No production code changes.

## Summary by Sourcery

Update unit tests for the asynchronous night-mode refactor and stabilize page-render completion test fixtures.

Bug Fixes:
- Update browser page night-mode coverage to validate the refactored asynchronous filter behavior without relying on the removed synchronous API.
- Prevent page-render-thread tests from crashing when exercising image completion handlers after the night-mode refactor.

Tests:
- Adapt night-mode and page-render-thread unit tests to the current asynchronous implementation and ensure the full test suite can run successfully.